### PR TITLE
Develop block 2.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,9 @@ We'd love your help! Here's a few things you can do:
 * Displays most common repeating events 
 * Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...)
 * End of repeating by COUNT or UNTIL
-* Exclude events on EXDATE from repeat 
-* By day month or by monthday (BYDAY, BYMONTH, BYMONTHDAY) no other by
-  (not parsed: BYYEARDAY, BYSETPOS, BYHOUR, BYMINUTE, WKST)
+* By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
+  (not parsed: BYYEARDAY, BYHOUR, BYMINUTE, WKST, RDATE)
+* Exclude events on EXDATE from repeat (after evaluating BYSETPOS)
 * Respects Timezone and Day Light Saving time. Build and tested with Iana timezones as used in php, Google, and Apple now also tested with Microsoft timezones and unknown timezones. For unknown timezone-names using the default timezone of Wordpress (probably the local timezone).  
 
 === Recurrent events, Timezone,  Daylight Saving Time ===
@@ -145,7 +145,7 @@ We'd love your help! Here's a few things you can do:
 Most users don't worry about time zones. The timezonesettings for the Wordpress installation, the calendar application and the events are all the same local time.   
 In that case this widget displays all the recurrent events with the same local times. The widget uses the properties of the starttime and duration (in seconds) of the first event to calculate the repeated events. Only when a calculated time is removed during the transition from ST (standard time, wintertime) to DST (daylight saving time, summertime) by turning the clock forward one hour, both the times of the event (in case the starttime is in the transition period) or only the endtime (in case only the endtime is in the transition period)  of the event are pushed forward with that same amount.    
 But because the transition period is usually very early in the morning, few events will be affected by it.   
-If a calculated day does not exist (i.e. February 30), the event will not be displayed.
+If a calculated day does not exist (i.e. February 30), the event will not be displayed. (Formally this should also happen to the time in the transition from ST to DST)   
 
 For users in countries that span more time zones, or users with international events the calendar applications can add a timezone to the event times. So users in other timezones will see the event in the local time in there timezone (as set in timezone settings of Wordpress) corresponding with the time.    
 The widget uses the starttime, the timezone of the starttime and the duration in seconds of the starting event as starting point for the calculation of repeating events. So if the events startime timezone does'not use daylight savings time and and timezone of the widget (i.e. the WP timezone setting) does. During DST the events are placed an hour later than during ST. (more precisely shift with the local time shift). Similar the events will be shift earlier when the timezone of the starttime has DST and the timezone of the widget not.   
@@ -194,8 +194,9 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 
 == Changelog ==
 * 2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. 
-  Use properties in IcsParser to limit copying of input params in several functions. 
-  //TODO Support  BYSETPOS
+  Use properties in IcsParser to limit copying of input params in several functions.
+  Solved issue: Warning: date() expects at most 2 parameters, 3 given in ...IcsParser.php on line 549 caused by wp_date() / date() replacement in v2.0.4.     
+  Support BYSETPOS in response to a github issue on the WP block of peppergrayxyz.
 * 2.0.4 Improvements IcsParser made as a result of porting to Joomla
 * notably solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
 * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ These are great, but as soon as you want to make a few adjustments to the stylin
 * Calendar block or widget to display appointments/events of a public Google calendar or other iCal file.
 * Block gives live preview in the editor and is not constrained to widget area. Old widget will be displayed in legacy widget block only in widget area.
 * Small footprint, uses only Google ID of the calendar, or ICS link for Outlook, or Url of iCal file, to get event information via iCal
+* Merge more calendars into one block
 * Manage events in Google Calendar, or other iCalendar source.
 * Fully adaptable to your website with CSS. Output in unordered list with Bootstrap 4 listgroup classes and toggle for details.
 * Choose date / time format in settings screen that best suits your website.
@@ -74,6 +75,13 @@ Then use the public iCal address or the Google calendar ID.
  You can find Google calendar ID by going to Calendar Settings / Calendars, clicking on the appropriate calendar, scrolling all the way down to find the Calendar ID at the bottom under the Integrate Calendar section. There's your calendar id.
  [More details on Google support](https://support.google.com/calendar/answer/37083#link)
 
+= How to merge more calendars into one module/block =  
+
+Fill a comma separated list of ID's in the Calendar ID field.      
+Optional you can add a html-class separated by a semicolon to some or all ID's to distinguish the descent in the lay-out of the event.   
+E.g.: #example;blue,https://p24-calendars.icloud.com/holiday/NL_nl.ics;red     
+Events of #example will be merged with events of NL holidays; html-class "blue" is added to all events of #example, html-class "red" to all events of NL holidays. 
+
 = Can I use HTML in the description of the appointement?  =
 
 You can use HTML in the most Calendars, but the result in the plugin may not be what you expect.    
@@ -121,6 +129,7 @@ We'd love your help! Here's a few things you can do:
 == Documentation ==
 
 * Gets calendar events via iCal url or google calendar ID
+* Merge more calendars into one block
 * Displays selected number of events, or events in a selected period from now as listgroup-items
 * Displays event start-date and summary; toggle details, description, start-, end-time, location. 
 * Displays most common repeating events 
@@ -182,6 +191,8 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * since v1.2.0 Wordpress version 5.3.0 is required because of the use of wp_date() 
 
 == Changelog ==
+* 2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. 
+  Use properties in IcsParser to limit copying of input params in several functions.  
 * 2.0.4 Improvements IcsParser made as a result of porting to Joomla
 * notably solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
 * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ We'd love your help! Here's a few things you can do:
 * Displays selected number of events, or events in a selected period from now as listgroup-items
 * Displays event start-date and summary; toggle details, description, start-, end-time, location. 
 * Displays most common repeating events 
-* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...), INTERVAL, WKST
+* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...), INTERVAL (default 1), WKST (default MO)
 * End of repeating by COUNT or UNTIL
 * By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
   (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Or just install it through the wordpress plugin directory.
 You can enter the block in a post or a page with the block-editor (eg. (+ sign)Toggle block inserter / WIDGETS).           
 If your theme has a widget area you can also enter the block as a widget in a widget area:          
  Appearance / Widgets / (+ sign)Toggle block inserter / WIDGETS. Just drag it into your sidebar.    
-* Alternative for WP 5.3 and higher: Select 'Simple Google Calendar Outlook Events Widget' or select the Legacy widget and choose 'Simple Google Calendar Outlook Events Widget'     
+* Alternative : Select 'Simple Google Calendar Outlook Events Widget' or select the Legacy widget and choose 'Simple Google Calendar Outlook Events Widget'     
   and drag it into the sidebar.
 * Fill out all the necessary configuration fields.
  In Calendar ID enter the calendar ID displayed by Google Calendar, or complete url of a  Google calendar or other iCal file.
@@ -133,10 +133,10 @@ We'd love your help! Here's a few things you can do:
 * Displays selected number of events, or events in a selected period from now as listgroup-items
 * Displays event start-date and summary; toggle details, description, start-, end-time, location. 
 * Displays most common repeating events 
-* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...)
+* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...), INTERVAL, WKST
 * End of repeating by COUNT or UNTIL
 * By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
-  (not parsed: BYYEARDAY, BYHOUR, BYMINUTE, WKST, RDATE)
+  (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)
 * Exclude events on EXDATE from repeat (after evaluating BYSETPOS)
 * Respects Timezone and Day Light Saving time. Build and tested with Iana timezones as used in php, Google, and Apple now also tested with Microsoft timezones and unknown timezones. For unknown timezone-names using the default timezone of Wordpress (probably the local timezone).  
 
@@ -196,7 +196,7 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * 2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. 
   Use properties in IcsParser to limit copying of input params in several functions.
   Solved issue: Warning: date() expects at most 2 parameters, 3 given in ...IcsParser.php on line 549 caused by wp_date() / date() replacement in v2.0.4.     
-  Support BYSETPOS in response to a github issue on the WP block of peppergrayxyz.
+  Support BYSETPOS in response to a github issue on the WP block of peppergrayxyz. Support WKST.   
 * 2.0.4 Improvements IcsParser made as a result of porting to Joomla
 * notably solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
 * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).

--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
   |____________|_________|________|_________|________|
   |BYDAY       |Limit    |Expand  |Note 1   |Note 2  |
   |____________|_________|________|_________|________|
+  |BYSETPOS    |Limit    |Limit   |Limit    |Limit   |
+  |____________|_________|________|_________|________|
  
     Note 1:  Limit if BYMONTHDAY is present; 
              otherwise, special expand for MONTHLY.
@@ -192,7 +194,8 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 
 == Changelog ==
 * 2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. 
-  Use properties in IcsParser to limit copying of input params in several functions.  
+  Use properties in IcsParser to limit copying of input params in several functions. 
+  //TODO Support  BYSETPOS
 * 2.0.4 Improvements IcsParser made as a result of porting to Joomla
 * notably solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
 * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).

--- a/simple-google-icalendar-widget/README.txt
+++ b/simple-google-icalendar-widget/README.txt
@@ -24,6 +24,7 @@ These are great, but as soon as you want to make a few adjustments to the stylin
 * Calendar block or widget to display appointments/events of a public Google calendar or other iCal file.
 * Block gives live preview in the editor and is not constrained to widget area. Old widget will be displayed in legacy widget block only in widget area.
 * Small footprint, uses only Google ID of the calendar, or ICS link for Outlook, or Url of iCal file, to get event information via iCal
+* Merge more calendars into one block
 * Manage events in Google Calendar, or other iCalendar source.
 * Fully adaptable to your website with CSS. Output in unordered list with Bootstrap 4 listgroup classes and toggle for details.
 * Choose date / time format in settings screen that best suits your website.
@@ -74,6 +75,13 @@ Then use the public iCal address or the Google calendar ID.
  You can find Google calendar ID by going to Calendar Settings / Calendars, clicking on the appropriate calendar, scrolling all the way down to find the Calendar ID at the bottom under the Integrate Calendar section. There's your calendar id.
  [More details on Google support](https://support.google.com/calendar/answer/37083#link)
 
+= How to merge more calendars into one module/block =  
+
+Fill a comma separated list of ID's in the Calendar ID field.      
+Optional you can add a html-class separated by a semicolon to some or all ID's to distinguish the descent in the lay-out of the event.   
+E.g.: #example;blue,https://p24-calendars.icloud.com/holiday/NL_nl.ics;red     
+Events of #example will be merged with events of NL holidays; html-class "blue" is added to all events of #example, html-class "red" to all events of NL holidays. 
+
 = Can I use HTML in the description of the appointement?  =
 
 You can use HTML in the most Calendars, but the result in the plugin may not be what you expect.    
@@ -121,6 +129,7 @@ We'd love your help! Here's a few things you can do:
 == Documentation ==
 
 * Gets calendar events via iCal url or google calendar ID
+* Merge more calendars into one block
 * Displays selected number of events, or events in a selected period from now as listgroup-items
 * Displays event start-date and summary; toggle details, description, start-, end-time, location. 
 * Displays most common repeating events 
@@ -182,6 +191,8 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * since v1.2.0 Wordpress version 5.3.0 is required because of the use of wp_date() 
 
 == Changelog ==
+* 2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. 
+  Use properties in IcsParser to limit copying of input params in several functions.  
 * 2.0.4 Improvements IcsParser made as a result of porting to Joomla
 * notably solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
 * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).

--- a/simple-google-icalendar-widget/README.txt
+++ b/simple-google-icalendar-widget/README.txt
@@ -133,7 +133,7 @@ We'd love your help! Here's a few things you can do:
 * Displays selected number of events, or events in a selected period from now as listgroup-items
 * Displays event start-date and summary; toggle details, description, start-, end-time, location. 
 * Displays most common repeating events 
-* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...), INTERVAL, WKST
+* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...), INTERVAL (default 1), WKST (default MO)
 * End of repeating by COUNT or UNTIL
 * By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
   (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)

--- a/simple-google-icalendar-widget/README.txt
+++ b/simple-google-icalendar-widget/README.txt
@@ -55,7 +55,7 @@ Or just install it through the wordpress plugin directory.
 You can enter the block in a post or a page with the block-editor (eg. (+ sign)Toggle block inserter / WIDGETS).           
 If your theme has a widget area you can also enter the block as a widget in a widget area:          
  Appearance / Widgets / (+ sign)Toggle block inserter / WIDGETS. Just drag it into your sidebar.    
-* Alternative for WP 5.3 and higher: Select 'Simple Google Calendar Outlook Events Widget' or select the Legacy widget and choose 'Simple Google Calendar Outlook Events Widget'     
+* Alternative : Select 'Simple Google Calendar Outlook Events Widget' or select the Legacy widget and choose 'Simple Google Calendar Outlook Events Widget'     
   and drag it into the sidebar.
 * Fill out all the necessary configuration fields.
  In Calendar ID enter the calendar ID displayed by Google Calendar, or complete url of a  Google calendar or other iCal file.
@@ -133,11 +133,11 @@ We'd love your help! Here's a few things you can do:
 * Displays selected number of events, or events in a selected period from now as listgroup-items
 * Displays event start-date and summary; toggle details, description, start-, end-time, location. 
 * Displays most common repeating events 
-* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...)
+* Frequency Yearly, Monthly, Weekly, Dayly (not parsed Hourly, Minutely ...), INTERVAL, WKST
 * End of repeating by COUNT or UNTIL
-* Exclude events on EXDATE from repeat 
-* By day month or by monthday (BYDAY, BYMONTH, BYMONTHDAY) no other by
-  (not parsed: BYYEARDAY, BYSETPOS, BYHOUR, BYMINUTE, WKST)
+* By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
+  (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)
+* Exclude events on EXDATE from repeat (after evaluating BYSETPOS)
 * Respects Timezone and Day Light Saving time. Build and tested with Iana timezones as used in php, Google, and Apple now also tested with Microsoft timezones and unknown timezones. For unknown timezone-names using the default timezone of Wordpress (probably the local timezone).  
 
 === Recurrent events, Timezone,  Daylight Saving Time ===
@@ -145,7 +145,7 @@ We'd love your help! Here's a few things you can do:
 Most users don't worry about time zones. The timezonesettings for the Wordpress installation, the calendar application and the events are all the same local time.   
 In that case this widget displays all the recurrent events with the same local times. The widget uses the properties of the starttime and duration (in seconds) of the first event to calculate the repeated events. Only when a calculated time is removed during the transition from ST (standard time, wintertime) to DST (daylight saving time, summertime) by turning the clock forward one hour, both the times of the event (in case the starttime is in the transition period) or only the endtime (in case only the endtime is in the transition period)  of the event are pushed forward with that same amount.    
 But because the transition period is usually very early in the morning, few events will be affected by it.   
-If a calculated day does not exist (i.e. February 30), the event will not be displayed.
+If a calculated day does not exist (i.e. February 30), the event will not be displayed. (Formally this should also happen to the time in the transition from ST to DST)   
 
 For users in countries that span more time zones, or users with international events the calendar applications can add a timezone to the event times. So users in other timezones will see the event in the local time in there timezone (as set in timezone settings of Wordpress) corresponding with the time.    
 The widget uses the starttime, the timezone of the starttime and the duration in seconds of the starting event as starting point for the calculation of repeating events. So if the events startime timezone does'not use daylight savings time and and timezone of the widget (i.e. the WP timezone setting) does. During DST the events are placed an hour later than during ST. (more precisely shift with the local time shift). Similar the events will be shift earlier when the timezone of the starttime has DST and the timezone of the widget not.   
@@ -168,6 +168,8 @@ see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
   |BYMONTHDAY  |Limit    |N/A     |Expand   |Expand  |
   |____________|_________|________|_________|________|
   |BYDAY       |Limit    |Expand  |Note 1   |Note 2  |
+  |____________|_________|________|_________|________|
+  |BYSETPOS    |Limit    |Limit   |Limit    |Limit   |
   |____________|_________|________|_________|________|
  
     Note 1:  Limit if BYMONTHDAY is present; 
@@ -192,7 +194,9 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 
 == Changelog ==
 * 2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. 
-  Use properties in IcsParser to limit copying of input params in several functions.  
+  Use properties in IcsParser to limit copying of input params in several functions.
+  Solved issue: Warning: date() expects at most 2 parameters, 3 given in ...IcsParser.php on line 549 caused by wp_date() / date() replacement in v2.0.4.     
+  Support BYSETPOS in response to a github issue on the WP block of peppergrayxyz. Support WKST.   
 * 2.0.4 Improvements IcsParser made as a result of porting to Joomla
 * notably solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
 * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -572,11 +572,11 @@ END:VCALENDAR';
                                                 ($fmdayok  || $expand
                                                     || $newstart->format('Ymd') != $edtstart->format('Ymd'))
                                                 && ($count == 0 || $i < $count)
-                                                && $newstart->getTimestamp() <= $until
+                                                && ($newstart->getTimestamp() <= $until || (false !== $bysetpos))
                                                 && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
-                                                && $newstart> $edtstart) { // count events after dtstart
+                                                && $newstart> $edtstart) { // count events after dtstart  
                                                 if (($newstart->getTimestamp() + $edurationsecs) >= $this->now
-                                                    ) { // copy only events after now
+                                                        ) { // copy only events after now
                                                         $cen++;
                                                         $en =  clone $e;
                                                         $en->start = $newstart->getTimestamp();
@@ -611,8 +611,10 @@ END:VCALENDAR';
                                     foreach ($evset as $evm){
                                         $si++;
                                         if (in_array($si, $bysetpos) || in_array($si - $cset, $bysetpos)) {
-                                            $evm->description = $evm->description . '<br>$cset=' . $cset . ';  $si=' .  $si . ';<br>$bysetpos=' . print_r($bysetpos, true);
-                                            $this->events[] = $evm;
+                                            if ($newstart->getTimestamp() <= $until) {
+                                                $evm->description = $evm->description . '<br>$cset=' . $cset . ';  $si=' .  $si . ';<br>$bysetpos=' . print_r($bysetpos, true);
+                                                $this->events[] = $evm;
+                                            }
                                         }
                                     }
                                     $evset = [];

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -543,6 +543,13 @@ END:VCALENDAR';
                                                         else  { // $frequency == 'WEEKLY' byi is not allowed so we dont parse it
                                                             $wdnrn = $newstart->format('N'); // Mo 1; Su 7
                                                             $wdnrb = array_search($byd,array_values(self::$weekdays)) + 1;  // numeric index in weekdays
+                                                            if (isset($rrules['wkst'])) {
+                                                                $wdnrws0 = array_search($rrules['wkst'],array_values(self::$weekdays));
+                                                                $wdnrn -= $wdnrws0;
+                                                                if (1 > $wdnrn) $wdnrn += 7;
+                                                                $wdnrb -= $wdnrws0;
+                                                                if (1 > $wdnrb) $wdnrb += 7;
+                                                            }
                                                             if ($wdnrb > $wdnrn) {
                                                                 $wdf->add (new \DateInterval('P' . ($wdnrb - $wdnrn ) . 'D'));
                                                             }
@@ -556,11 +563,10 @@ END:VCALENDAR';
                                                         
                                                     } // foreach
                                             } // expand
-                                            else { // limit frequency period smaller than Week//
+                                            else { // limit frequency period smaller than Week (DAILY)//
                                                 // intval (byi) is not allowed with a frquency other than YEARLY or MONTHLY so
                                                 // RRULE:FREQ=DAILY;BYDAY=-1SU; won't give any reptition.
-                                                if ($byday == array('')
-                                                    || in_array(strtoupper(substr($newstart->format('D'),0,2 )), $byday) //TODO condition $fmdayok && needed??
+                                                if ($byday == array('') || in_array(strtoupper(substr($newstart->format('D'),0,2 )), $byday)
                                                     ){ // only one time in this loop no change of $newstart
                                                         $fset[] =  $newstart->getTimestamp();
                                                 } else {

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -39,7 +39,7 @@
  *   Removed htmlspecialchars() from summary, description and location, to replace it in the output template/block
  *   Combined getFutureEvents and Limit array. usort eventsortcomparer now on start, end, cal_ord and with arithmic subtraction because all are integers.
  *   Parse event DURATION; (only) When DTEND is empty: determine end from start plus duration, when duration is empty and start is DATE start plus one day, else = start
- *   Parse event BYSETPOS; \\TODO ...   
+ *   Parse event BYSETPOS; Parse WKST (default MO) 
  */
 namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
 
@@ -586,7 +586,7 @@ END:VCALENDAR';
                                             $newstart->setTimestamp($by) ;
                                         }
                                         if (
-                                            ($fmdayok || $expand)  //TODO what if !$fmdayok
+                                            ($fmdayok || $expand)
                                             && ($count == 0 || $i < $count)
                                             && $newstart->getTimestamp() <= $until
                                             && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -436,6 +436,7 @@ END:VCALENDAR';
                                 $fH = $freqstart->format('H'); // 24-hour format of an hour with leading zeros
                                 $fi = $freqstart->format('i'); // Minutes with leading zeros
                                 $expand = false;
+                                $fset = [];
                                 // bymonth
                                 if (isset($rrules['bymonth'])) {
                                     $bym = array();
@@ -489,7 +490,6 @@ END:VCALENDAR';
                                         $byn= array_unique($byn); // make unique
                                         sort($byn);	// order array so that oldest items first are counted
                                     } else {$byn = array('');}
-                                    
                                     foreach ($byn as $by) {
                                         if (isset($rrules['bymonthday'])){
                                             if (in_array($frequency , array('MONTHLY', 'YEARLY')) ){ // expand
@@ -504,7 +504,6 @@ END:VCALENDAR';
                                         } else { // passthrough
                                         }
                                         // byday
-                                        $bydays = array();
                                         if (isset($rrules['byday'])){
                                             if (in_array($frequency , array('WEEKLY','MONTHLY', 'YEARLY'))
                                                 && (! isset($rrules['bymonthday']))
@@ -528,15 +527,15 @@ END:VCALENDAR';
                                                             $wdl->setTime($fH, $fi);
                                                             if ($byi > 0) {
                                                                 $wdf->add(new \DateInterval('P' . ($byi - 1) . 'W'));
-                                                                $bydays[] = $wdf->getTimestamp();
+                                                                $fset[] = $wdf->getTimestamp();
                                                             } elseif ($byi < 0) {
                                                                 $wdl->sub(new \DateInterval('P' . (- $byi - 1) . 'W'));
-                                                                $bydays[] = $wdl->getTimestamp();
+                                                                $fset[] = $wdl->getTimestamp();
                                                                 
                                                             }
                                                             else {
                                                                 while ($wdf <= $wdl) {
-                                                                    $bydays[] = $wdf->getTimestamp();
+                                                                    $fset[] = $wdf->getTimestamp();
                                                                     $wdf->add(new \DateInterval('P1W'));
                                                                 }
                                                             }
@@ -551,7 +550,7 @@ END:VCALENDAR';
                                                                 $wdf->sub (new \DateInterval('P' . ($wdnrn - $wdnrb) . 'D'));
                                                                 
                                                             }
-                                                            $bydays[] = $wdf->getTimestamp();
+                                                            $fset[] = $wdf->getTimestamp();
                                                             
                                                         } // Weekly
                                                         
@@ -563,64 +562,64 @@ END:VCALENDAR';
                                                 if ($byday == array('')
                                                     || in_array(strtoupper(substr($newstart->format('D'),0,2 )), $byday) //TODO condition $fmdayok && needed??
                                                     ){ // only one time in this loop no change of $newstart
-                                                        $bydays =  array('');
+                                                        $fset[] =  $newstart->getTimestamp();
                                                 } else {
                                                     continue;
                                                 }
                                             } // limit
                                         } // isset byday
-                                        else {$bydays = array('');
+                                        else {$fset[] =  $newstart->getTimestamp();
                                         }
-                                        $bydays= array_unique($bydays); // make unique
-                                        sort($bydays);	// order array so that oldest items first are counted
-                                        $cset = count($bydays) + 1;
-                                        $si = 0;
-                                        foreach ($bydays as $by) {
-                                            $si++;
-                                            if (false === $bysetpos || in_array($si, $bysetpos) || in_array($si - $cset, $bysetpos)) {
-                                                if (intval($by) > 0 ) {
-                                                    $newstart->setTimestamp($by) ;
-                                                }
-                                                if (
-                                                    ($fmdayok || $expand)  //TODO what if !$fmdayok
-                                                    && ($count == 0 || $i < $count)
-                                                    && $newstart->getTimestamp() <= $until
-                                                    && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
-                                                    && $newstart> $edtstart) { // count events after dtstart  
-                                                    if ($newstart->getTimestamp() > $nowstart
-                                                            ) { // copy only events after now
-                                                            $en =  clone $e;
-                                                            $en->start = $newstart->getTimestamp();
-                                                            $en->end = $en->start + $edurationsecs;
-                                                            if ($en->startisdate ){ //
+                                    } // end bymonthday
+                                } // end bymonth
+                                $fset= array_unique($fset); // make unique
+                                sort($fset);	// order array so that oldest items first are counted
+                                $cset = count($fset) + 1;
+                                $si = 0;
+                                foreach ($fset as $by) {
+                                    $si++;
+                                    if (false === $bysetpos || in_array($si, $bysetpos) || in_array($si - $cset, $bysetpos)) {
+                                        if (intval($by) > 0 ) {
+                                            $newstart->setTimestamp($by) ;
+                                        }
+                                        if (
+                                            ($fmdayok || $expand)  //TODO what if !$fmdayok
+                                            && ($count == 0 || $i < $count)
+                                            && $newstart->getTimestamp() <= $until
+                                            && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
+                                            && $newstart> $edtstart) { // count events after dtstart
+                                                if ($newstart->getTimestamp() > $nowstart
+                                                    ) { // copy only events after now
+                                                        $en =  clone $e;
+                                                        $en->start = $newstart->getTimestamp();
+                                                        $en->end = $en->start + $edurationsecs;
+                                                        if ($en->startisdate ){ //
+                                                            $enddate = date_create( '@' . $en->end );
+                                                            $enddate->setTimezone( $timezone );
+                                                            $endtime= $enddate->format('His');
+                                                            if ('000000' < $endtime){
+                                                                if ('120000' < $endtime) $en->end = $en->end + 86400;
                                                                 $enddate = date_create( '@' . $en->end );
                                                                 $enddate->setTimezone( $timezone );
-                                                                $endtime= $enddate->format('His');
-                                                                if ('000000' < $endtime){
-                                                                    if ('120000' < $endtime) $en->end = $en->end + 86400;
-                                                                    $enddate = date_create( '@' . $en->end );
-                                                                    $enddate->setTimezone( $timezone );
-                                                                    $enddate->setTime(0,0,0);
-                                                                    $en->end = $enddate->getTimestamp();
-                                                                }
+                                                                $enddate->setTime(0,0,0);
+                                                                $en->end = $enddate->getTimestamp();
                                                             }
-                                                            $en->uid = $i . '_' . $e->uid;
-                                                            if ($test > ' ') { 	$en->summary = $en->summary . '<br>Test:' . $test; 	}
-                                                            $this->events[] = $en;
-                                                            if (false !== $bysetpos) {
+                                                        }
+                                                        $en->uid = $i . '_' . $e->uid;
+                                                        if ($test > ' ') { 	$en->summary = $en->summary . '<br>Test:' . $test; 	}
+                                                        $this->events[] = $en;
+                                                        if (false !== $bysetpos) {
                                                             $en->description = $en->description . '<br>$cset=' . $cset . ';  $si=' .  $si . ';<br>$bysetpos=' . print_r($bysetpos, true)
                                                             . ';<br>$this->penddate=' . date('Y-m-d H:i:s', $this->penddate). ';<br>$freqstartparse=' . date('Y-m-d H:i:s', $freqstartparse )
                                                             . ';<br>$freqstart=' . $freqstart->format('Y-m-d H:i:s')
                                                             . ';<br>$freqendloop=' . date('Y-m-d H:i:s',$freqendloop);
-                                                            }
-                                                    } // copy events
-                                                    // next eventcount from $e->start (also before now)
-                                                    $i++;
-                                                } // end count events
-                                            } // end bysetpos
-                                        } // end byday
-                                    } // end bymonthday
-                                } // end bymonth
+                                                        }
+                                                } // copy events
+                                                // next eventcount from $e->start (also before now)
+                                                $i++;
+                                        } // end count events
+                                    } // end bysetpos
+                                } // end byday
                             } // end > $freqstartparse
                             // next startdate by FREQ
                             $freqstart->add($freqinterval);

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -38,7 +38,8 @@
  *   Make properties from most important parameters during instantiation of the class to limit copying of input params in several functions.
  *   Removed htmlspecialchars() from summary, description and location, to replace it in the output template/block
  *   Combined getFutureEvents and Limit array. usort eventsortcomparer now on start, end, cal_ord and with arithmic subtraction because all are integers.
- *   Parse event DURATION; (only) When DTEND is empty: determine end from start plus duration, when duration is empty and start is DATE start plus one day, else = start  
+ *   Parse event DURATION; (only) When DTEND is empty: determine end from start plus duration, when duration is empty and start is DATE start plus one day, else = start
+ *   Parse event BYSETPOS; \\TODO ...   
  */
 namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
 
@@ -352,7 +353,7 @@ END:VCALENDAR';
                      * FREQ=WEEKLY;COUNT=10;BYDAY=MO,TU,WE,TH,FR Every week 10 times on weekdays
                      * FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU every year last sunday of october
                      * FREQ=DAILY;COUNT=5;INTERVAL=7 Every 7 days,5 times
-                     
+//TODO                     * FREQ=MONTHLY;BYDAY=MO,TU,WE,TH,FR;BYSETPOS=1,-1 represents the first and the last work day of the month:   
                      */
                     $timezone = new \DateTimeZone((isset($e->tzid)&& $e->tzid !== '') ? $e->tzid : $this->timezone_string);
                     $edtstart = new \DateTime('@' . $e->start);
@@ -401,6 +402,7 @@ END:VCALENDAR';
                     $bymonth = explode(',', (isset($rrules['bymonth'])) ? $rrules['bymonth'] : '');
                     $bymonthday = explode(',', (isset($rrules['bymonthday'])) ? $rrules['bymonthday'] : '');
                     $byday = explode(',', (isset($rrules['byday'])) ? $rrules['byday'] : '');
+                    $bysetpos = explode(',', (isset($rrules['bysetpos'])) ? $rrules['bysetpos'] : '');
                     $i = 1;
                     $cen = 0;
                     switch ($frequency){

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -544,7 +544,7 @@ END:VCALENDAR';
                                                             $wdnrn = $newstart->format('N'); // Mo 1; Su 7
                                                             $wdnrb = array_search($byd,array_values(self::$weekdays)) + 1;  // numeric index in weekdays
                                                             if (isset($rrules['wkst'])) {
-                                                                $wdnrws0 = array_search($rrules['wkst'],array_values(self::$weekdays));
+                                                                $wdnrws0 = array_search($rrules['wkst'],array_keys(self::$weekdays));
                                                                 $wdnrn -= $wdnrws0;
                                                                 if (1 > $wdnrn) $wdnrn += 7;
                                                                 $wdnrb -= $wdnrws0;
@@ -555,12 +555,9 @@ END:VCALENDAR';
                                                             }
                                                             if ($wdnrb < $wdnrn) {
                                                                 $wdf->sub (new \DateInterval('P' . ($wdnrn - $wdnrb) . 'D'));
-                                                                
                                                             }
                                                             $fset[] = $wdf->getTimestamp();
-                                                            
                                                         } // Weekly
-                                                        
                                                     } // foreach
                                             } // expand
                                             else { // limit frequency period smaller than Week (DAILY)//
@@ -614,12 +611,6 @@ END:VCALENDAR';
                                                         $en->uid = $i . '_' . $e->uid;
                                                         if ($test > ' ') { 	$en->summary = $en->summary . '<br>Test:' . $test; 	}
                                                         $this->events[] = $en;
-                                                        if (false !== $bysetpos) {
-                                                            $en->description = $en->description . '<br>$cset=' . $cset . ';  $si=' .  $si . ';<br>$bysetpos=' . print_r($bysetpos, true)
-                                                            . ';<br>$this->penddate=' . date('Y-m-d H:i:s', $this->penddate). ';<br>$freqstartparse=' . date('Y-m-d H:i:s', $freqstartparse )
-                                                            . ';<br>$freqstart=' . $freqstart->format('Y-m-d H:i:s')
-                                                            . ';<br>$freqendloop=' . date('Y-m-d H:i:s',$freqendloop);
-                                                        }
                                                 } // copy events
                                                 // next eventcount from $e->start (also before now)
                                                 $i++;
@@ -787,18 +778,20 @@ END:VCALENDAR';
             //     eg. DTSTART;TZID=Europe/Amsterdam, or  DTSTART;VALUE=DATE:20171203
             $tl = explode(";", $list[0]);
             $token = $tl[0];
-            if (count($tl) > 1 ){
-                $dtl = explode("=", $tl[1]);
+            $i = 1;
+            while (count($tl) > $i ){
+                $dtl = explode("=", $tl[$i]);
                 if (count($dtl) > 1 ){
                     switch($dtl[0]) {
                         case 'TZID':
                             $tzid = $dtl[1];
                             break;
                         case 'VALUE':
-                            $isdate = (substr( $dtl[1],0,4) == 'DATE');
+                            $isdate = ('DATE' == $dtl[1]);
                             break;
                     }
                 }
+                $i++;
             }
             if (count($list) > 1 && strlen($token) > 1 && substr($token, 0, 1) > ' ') { //all tokens start with a alphabetic char , otherwise it is a continuation of a description with a colon in it.
                 // trim() to remove \n\r\0

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -606,7 +606,7 @@ END:VCALENDAR';
                                 } // end bymonth
                                 if (false !== $bysetpos) { // process set
                                     usort($evset, array($this, "eventSortComparer"));
-                                    $cset = count($bysetpos) + 1;
+                                    $cset = count($evset) + 1;
                                     $si = 0;
                                     foreach ($evset as $evm){
                                         $si++;

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -561,7 +561,7 @@ END:VCALENDAR';
                                                 // intval (byi) is not allowed with a frquency other than YEARLY or MONTHLY so
                                                 // RRULE:FREQ=DAILY;BYDAY=-1SU; won't give any reptition.
                                                 if ($byday == array('')
-                                                    || in_array(strtoupper(substr($newstart->format('D'),0,2 )), $byday)
+                                                    || in_array(strtoupper(substr($newstart->format('D'),0,2 )), $byday) //TODO condition $fmdayok && needed??
                                                     ){ // only one time in this loop no change of $newstart
                                                         $bydays =  array('');
                                                 } else {
@@ -582,7 +582,7 @@ END:VCALENDAR';
                                                     $newstart->setTimestamp($by) ;
                                                 }
                                                 if (
-                                                    ($fmdayok || $expand || $newstart->format('Ymd') != $edtstart->format('Ymd'))
+                                                    ($fmdayok || $expand)  //TODO what if !$fmdayok
                                                     && ($count == 0 || $i < $count)
                                                     && $newstart->getTimestamp() <= $until
                                                     && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
@@ -593,14 +593,12 @@ END:VCALENDAR';
                                                             $en->start = $newstart->getTimestamp();
                                                             $en->end = $en->start + $edurationsecs;
                                                             if ($en->startisdate ){ //
-                                                                $enddate = date_create( '@' . $en->end ); //TODO repair and test for DST transition
+                                                                $enddate = date_create( '@' . $en->end );
                                                                 $enddate->setTimezone( $timezone );
                                                                 $endtime= $enddate->format('His');
-//                                                                    $endtime = wp_date('His', $en->end, $timezone);
                                                                 if ('000000' < $endtime){
                                                                     if ('120000' < $endtime) $en->end = $en->end + 86400;
-//                                                                        $enddate = \DateTime::createFromFormat('Y-m-d H:i:s', wp_date('Y-m-d 00:00:00', $en->end, $timezone), $timezone );
-                                                                    $enddate = date_create( '@' . $en->end ); //TODO repair and test for DST transition
+                                                                    $enddate = date_create( '@' . $en->end );
                                                                     $enddate->setTimezone( $timezone );
                                                                     $enddate->setTime(0,0,0);
                                                                     $en->end = $enddate->getTimestamp();

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -593,10 +593,16 @@ END:VCALENDAR';
                                                             $en->start = $newstart->getTimestamp();
                                                             $en->end = $en->start + $edurationsecs;
                                                             if ($en->startisdate ){ //
-                                                                $endtime = date('His', $en->end, $timezone); //TODO repair and test for DST transition 
+                                                                $enddate = date_create( '@' . $en->end ); //TODO repair and test for DST transition
+                                                                $enddate->setTimezone( $timezone );
+                                                                $endtime= $enddate->format('His');
+//                                                                    $endtime = wp_date('His', $en->end, $timezone);
                                                                 if ('000000' < $endtime){
                                                                     if ('120000' < $endtime) $en->end = $en->end + 86400;
-                                                                    $enddate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:00', $en->end, $timezone), $timezone );
+//                                                                        $enddate = \DateTime::createFromFormat('Y-m-d H:i:s', wp_date('Y-m-d 00:00:00', $en->end, $timezone), $timezone );
+                                                                    $enddate = date_create( '@' . $en->end ); //TODO repair and test for DST transition
+                                                                    $enddate->setTimezone( $timezone );
+                                                                    $enddate->setTime(0,0,0);
                                                                     $en->end = $enddate->getTimestamp();
                                                                 }
                                                             }

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -611,6 +611,7 @@ END:VCALENDAR';
                                     foreach ($evset as $evm){
                                         $si++;
                                         if (in_array($si, $bysetpos) || in_array($si - $cset, $bysetpos)) {
+                                            $evm->description = $evm->description . '<br>$cset=' . $cset . ';  $si=' .  $si . ';<br>$bysetpos=' . print_r($bysetpos, true);
                                             $this->events[] = $evm;
                                         }
                                     }

--- a/simple-google-icalendar-widget/includes/IcsParser.php
+++ b/simple-google-icalendar-widget/includes/IcsParser.php
@@ -575,30 +575,31 @@ END:VCALENDAR';
                                                 && $newstart->getTimestamp() <= $until
                                                 && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
                                                 && $newstart> $edtstart) { // count events after dtstart
-                                                    if (($newstart->getTimestamp() + $edurationsecs) >= $this->now
-                                                        ) { // copy only events after now
-                                                            $cen++;
-                                                            $en =  clone $e;
-                                                            $en->start = $newstart->getTimestamp();
-                                                            $en->end = $en->start + $edurationsecs;
-                                                            if ($en->startisdate ){ //
-                                                                $endtime = date('His', $en->end, $timezone);
-                                                                if ('000000' < $endtime){
-                                                                    if ('120000' < $endtime) $en->end = $en->end + 86400;
-                                                                    $enddate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:00', $en->end, $timezone), $timezone );
-                                                                    $en->end = $enddate->getTimestamp();
-                                                                }
+                                                if (($newstart->getTimestamp() + $edurationsecs) >= $this->now
+                                                    ) { // copy only events after now
+                                                        $cen++;
+                                                        $en =  clone $e;
+                                                        $en->start = $newstart->getTimestamp();
+                                                        $en->end = $en->start + $edurationsecs;
+                                                        if ($en->startisdate ){ //
+                                                            $endtime = date('His', $en->end, $timezone);
+                                                            if ('000000' < $endtime){
+                                                                if ('120000' < $endtime) $en->end = $en->end + 86400;
+                                                                $enddate = \DateTime::createFromFormat('Y-m-d H:i:s', date('Y-m-d 00:00:00', $en->end, $timezone), $timezone );
+                                                                $en->end = $enddate->getTimestamp();
                                                             }
-                                                            $en->uid = $i . '_' . $e->uid;
-                                                            if ($test > ' ') { 	$en->summary = $en->summary . '<br>Test:' . $test; 	}
-                                                            if (false === $bysetpos) {
-                                                                $this->events[] = $en;
-                                                                $i++;
-                                                            } else { // add to set
-                                                                $evset[] = $en;
-                                                            }
-                                                                
-                                                    } // copy eevents
+                                                        }
+                                                        $en->uid = $i . '_' . $e->uid;
+                                                        if ($test > ' ') { 	$en->summary = $en->summary . '<br>Test:' . $test; 	}
+                                                        if (false === $bysetpos) {
+                                                            $this->events[] = $en;
+                                                        } else { // add to set
+                                                            $evset[] = $en;
+                                                        }
+                                                            
+                                                } // copy eevents
+                                                // next eventcount from $e->start (also before now)
+                                                $i++;
                                             } // end count events
                                         } // end byday
                                     } // end bymonthday
@@ -611,7 +612,6 @@ END:VCALENDAR';
                                         $si++;
                                         if (in_array($si, $bysetpos) || in_array($si - $cset, $bysetpos)) {
                                             $this->events[] = $evm;
-                                            $i++;
                                         }
                                     }
                                     $evset = [];

--- a/simple-google-icalendar-widget/includes/SimpleicalBlock.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalBlock.php
@@ -176,7 +176,7 @@ class SimpleicalBlock {
                     }
                     }
                     $e->description = str_replace("\n", '<br>', wp_kses($e->description,'post') );
-                    echo   $e->description ,(strrpos($e->description, '<br>') == (strlen($e->description) - 4)) ? '' : '<br>';
+                    echo   $e->description ,(strrpos($e->description, '<br>') === (strlen($e->description) - 4)) ? '' : '<br>';
                 }
                 if ($e->startisdate === false && date('yz', $e->start) === date('yz', $e->end))	{
                     echo '<span class="time">', wp_kses(wp_date( $dftstart, $e->start ), 'post'),

--- a/simple-google-icalendar-widget/includes/SimpleicalBlock.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalBlock.php
@@ -19,6 +19,9 @@
  *  excerptlength string and in javascript  '' when not parsed as integer. 
  * 20220526 added example 
  * 20220620 added enddate/times for startdate and starttime added Id as anchor and choice of tagg for summary, collaps only when tag_for summary = a.
+ * 2.1.0 add calendar class to list-group-item
+ *   add htmlspecialchars() to summary, description and location when not 'allowhtml', replacing similar code from IcsParser
+
  */
 namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
 
@@ -135,11 +138,16 @@ class SimpleicalBlock {
                 $idlist = explode("@", esc_attr($e->uid) );
                 $itemid = $instance['blockid'] . '_' . $idlist[0]; //TODO find correct block id when duplicate
                 $evdate = wp_kses(wp_date( $dflg, $e->start), 'post');
+                if ( !$instance['allowhtml']) {
+                    $e->summary = htmlspecialchars($e->summary);
+                    $e->description = htmlspecialchars($e->description);
+                    $e->location = htmlspecialchars($e->location);
+                }
                 if (date('yz', $e->start) != date('yz', $e->end)) {
                     $evdate = str_replace(array("</div><div>", "</h4><h4>", "</h5><h5>", "</h6><h6>" ), '', $evdate . wp_kses(wp_date( $dflgend, $e->end - 1) , 'post'));
                 }
                 $evdtsum = (($e->startisdate === false) ? wp_kses(wp_date( $dftsum, $e->start) . wp_date( $dftsend, $e->end), 'post') : '');
-                echo '<li class="list-group-item' .  $sflgi . '">';
+                echo '<li class="list-group-item' .  $sflgi . ' ' . sanitize_html_class($e->cal_class) . '">';
                 if (!$startwsum && $curdate != $evdate ) {
                     $curdate =  $evdate;
                     echo '<span class="ical-date">' . ucfirst($evdate) . '</span>' . (('a' == $instance['tag_sum'] ) ? '<br>': '');

--- a/simple-google-icalendar-widget/includes/SimpleicalBlock.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalBlock.php
@@ -136,18 +136,18 @@ class SimpleicalBlock {
             $curdate = '';
             foreach($data as $e) {
                 $idlist = explode("@", esc_attr($e->uid) );
-                $itemid = $instance['blockid'] . '_' . $idlist[0]; //TODO find correct block id when duplicate
+                $itemid = $instance['blockid'] . '_' . $idlist[0]; 
                 $evdate = wp_kses(wp_date( $dflg, $e->start), 'post');
                 if ( !$instance['allowhtml']) {
-                    $e->summary = htmlspecialchars($e->summary);
-                    $e->description = htmlspecialchars($e->description);
-                    $e->location = htmlspecialchars($e->location);
+                    if (!empty($e->summary)) $e->summary = htmlspecialchars($e->summary);
+                    if (!empty($e->description)) $e->description = htmlspecialchars($e->description);
+                    if (!empty($e->location)) $e->location = htmlspecialchars($e->location);
                 }
                 if (date('yz', $e->start) != date('yz', $e->end)) {
                     $evdate = str_replace(array("</div><div>", "</h4><h4>", "</h5><h5>", "</h6><h6>" ), '', $evdate . wp_kses(wp_date( $dflgend, $e->end - 1) , 'post'));
                 }
                 $evdtsum = (($e->startisdate === false) ? wp_kses(wp_date( $dftsum, $e->start) . wp_date( $dftsend, $e->end), 'post') : '');
-                echo '<li class="list-group-item' .  $sflgi . ' ' . sanitize_html_class($e->cal_class) . '">';
+                echo '<li class="list-group-item' .  $sflgi . ((!empty($e->location)) ? ' ' . sanitize_html_class($e->cal_class): '') . '">';
                 if (!$startwsum && $curdate != $evdate ) {
                     $curdate =  $evdate;
                     echo '<span class="ical-date">' . ucfirst($evdate) . '</span>' . (('a' == $instance['tag_sum'] ) ? '<br>': '');

--- a/simple-google-icalendar-widget/includes/SimpleicalBlock.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalBlock.php
@@ -147,7 +147,7 @@ class SimpleicalBlock {
                     $evdate = str_replace(array("</div><div>", "</h4><h4>", "</h5><h5>", "</h6><h6>" ), '', $evdate . wp_kses(wp_date( $dflgend, $e->end - 1) , 'post'));
                 }
                 $evdtsum = (($e->startisdate === false) ? wp_kses(wp_date( $dftsum, $e->start) . wp_date( $dftsend, $e->end), 'post') : '');
-                echo '<li class="list-group-item' .  $sflgi . ((!empty($e->location)) ? ' ' . sanitize_html_class($e->cal_class): '') . '">';
+                echo '<li class="list-group-item' .  $sflgi . ((!empty($e->cal_class)) ? ' ' . sanitize_html_class($e->cal_class): '') . '">';
                 if (!$startwsum && $curdate != $evdate ) {
                     $curdate =  $evdate;
                     echo '<span class="ical-date">' . ucfirst($evdate) . '</span>' . (('a' == $instance['tag_sum'] ) ? '<br>': '');

--- a/simple-google-icalendar-widget/includes/SimpleicalBlock.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalBlock.php
@@ -10,7 +10,7 @@
  * @license    http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Gutenberg Block functions
  * used in newer wp versions where Gutenbergblocks are available. (tested with function_exists( 'register_block_type' ))
- * Version: 2.0.4
+ * Version: 2.1.0
  * 20220427 namespaced and renamed after classname.
  * 20220430 try with static calls
  * 20220509 fairly correct front-end display. attributes back to block.json

--- a/simple-google-icalendar-widget/includes/SimpleicalWidgetAdmin.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalWidgetAdmin.php
@@ -9,8 +9,9 @@
  * @copyright  Copyright (c)  2017 - 2022, Bram Waasdorp
  * @link       https://github.com/bramwaas/wordpress-plugin-wsa-simple-google-calendar-widget
  * @license    http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Version: 2.0.3
+ * Version: 2.1.0
  * 20220410 namespaced and renamed after classname.
+ * 2.1.0 option for comma seperated list of IDs
  */
 namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
 
@@ -52,9 +53,10 @@ class SimpleicalWidgetAdmin {
         _e('<p><strong>Title</strong></p>', 'simple_ical');
         _e('<p>Title of this instance of the widget</p>', 'simple_ical');
         
-        _e('<p><strong>Calendar ID, or iCal URL</strong></p>', 'simple_ical');
-        _e('<p>The Google calendar ID, or the URL of te iCal file to display.</p>', 'simple_ical');
+        _e('<p><strong>Calendar ID(s), or iCal URL</strong></p>', 'simple_ical');
+        _e('<p>The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID&apos;s.</p>', 'simple_ical');
         _e('<p>In the block you can use #example to get example events</p>', 'simple_ical');
+        _e('<p>Or a comma separated list of ID&apos;s; optional you can add a html-class separated by a semicolon to some or all ID&apos;s to distinguish the descent in the lay-out of the event.</p>', 'simple_ical');
         
         _e('<p><strong>Number of events displayed</strong></p>', 'simple_ical');
         _e('<p>The maximum number of events to display.</p>', 'simple_ical');

--- a/simple-google-icalendar-widget/includes/SimpleicalWidgetAdmin.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalWidgetAdmin.php
@@ -55,7 +55,7 @@ class SimpleicalWidgetAdmin {
         
         _e('<p><strong>Calendar ID(s), or iCal URL</strong></p>', 'simple_ical');
         _e('<p>The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID&apos;s.</p>', 'simple_ical');
-        _e('<p>In the block you can use #example to get example events</p>', 'simple_ical');
+        _e('<p>You can use #example to get example events</p>', 'simple_ical');
         _e('<p>Or a comma separated list of ID&apos;s; optional you can add a html-class separated by a semicolon to some or all ID&apos;s to distinguish the descent in the lay-out of the event.</p>', 'simple_ical');
         
         _e('<p><strong>Number of events displayed</strong></p>', 'simple_ical');

--- a/simple-google-icalendar-widget/includes/SimpleicalWidgetAdmin.php
+++ b/simple-google-icalendar-widget/includes/SimpleicalWidgetAdmin.php
@@ -90,8 +90,8 @@ class SimpleicalWidgetAdmin {
 
         _e('<h3>Advanced settings</h3>' );
         
-        _e('<p><strong>Cache expiration time in minutes</strong></p>', 'simple_ical');
-        _e('<p>Minimal time in minutes between reads from source.</p>', 'simple_ical');
+        _e('<p><strong>Calendar cache expiration time in minutes</strong></p>', 'simple_ical');
+        _e('<p>Minimal time in minutes between reads from calendar source.</p>', 'simple_ical');
         
         _e('<p><strong>Excerpt length</strong></p>', 'simple_ical');
         _e('<p>Max length of the description in characters.<br>If there is a space or end-of-line character within 10 characters of this end, break there.<br>Note, not all characters have the same width, so the number of lines is not completely fixed by this. So you need additional CSS for that.<br><b>Warning:</b> If you allow html in the description, necessary end tags may disappear here.<br> Default: empty, all characters will be displayed</p>', 'simple_ical');

--- a/simple-google-icalendar-widget/simple-google-icalendar-widget.php
+++ b/simple-google-icalendar-widget/simple-google-icalendar-widget.php
@@ -4,7 +4,7 @@
  Description: Widget that displays events from a public google calendar or iCal file
  Plugin URI: https://github.com/bramwaas/wordpress-plugin-wsa-simple-google-calendar-widget
  Author: Bram Waasdorp
- Version: 2.0.4
+ Version: 2.1.0
  License: GPL3
  Tested up to: 6.0
  Requires at least: 5.3


### PR DESCRIPTION
2.1.0 Support more calendars in one module/block. Support DURATION of event. Move processing 'allowhtml' complete out Parser to template/block. Use properties in IcsParser to limit copying of input params in several functions. Solved issue: Warning: date() expects at most 2 parameters, 3 given in ...IcsParser.php on line 549 caused by wp_date() / date() replacement in v2.0.4.
Support BYSETPOS in response to a github issue on the WP block of peppergrayxyz. Support WKST.