### PR TITLE
v2.2.0 Develop block

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Plugin name: Simple Google Calendar Outlook Events Block Widget
 Contributors: bramwaas
 Tags: Event Calendar, Google Calendar, iCal, Events, Block, Calendar, iCalendar, Outlook, iCloud
 Requires at least: 5.3.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.3.0
 Stable tag: trunk
 License: GPLv2 or later
@@ -144,7 +144,7 @@ We'd love your help! Here's a few things you can do:
 * End of repeating by COUNT or UNTIL
 * By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
   (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)
-* Exclude events on EXDATE from repeat (after evaluating BYSETPOS)
+* Exclude events on EXDATE from recurrence set (after evaluating BYSETPOS)
 * Respects Timezone and Day Light Saving time. Build and tested with Iana timezones as used in php, Google, and Apple now also tested with Microsoft timezones and unknown timezones. For unknown timezone-names using the default timezone of Wordpress (probably the local timezone).  
 
 === Recurrent events, Timezone,  Daylight Saving Time ===
@@ -166,6 +166,7 @@ Test results and comparison with Google and Outlook calendar have been uploaded 
 === From the ical specifications ===
 ~~~
 see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
+or https://icalendar.org/iCalendar-RFC-5545/
 (see 3.3.10. [Page 38] Recurrence Rule in specification
   .____________._________.________._________.________.
   |            |DAILY    |WEEKLY  |MONTHLY  |YEARLY  |
@@ -202,7 +203,8 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * since v1.2.0 Wordpress version 5.3.0 is required because of the use of wp_date() 
 
 == Changelog ==
-
+* 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
+' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
 * 2.1.5 20230824 after an issue of johansam (@johansam) in wp support forum: 'Warning: Undefined array key
 ' reviewed and improved initialising of options for legacy widget.
 * 2.1.4 20230725 tested with WordPress 6.3-RC1 running Twenty Twenty-Two theme.    

--- a/README.md
+++ b/README.md
@@ -125,6 +125,42 @@ Check if you can download the ics file you have designated in the widget with a 
 
  Yes you can, since v1.2.0, I have tested with [https://p24-calendars.icloud.com/holiday/NL_nl.ics](https://p24-calendars.icloud.com/holiday/NL_nl.ics) .
 
+= How do I set different colours and text size for the dates, the summary, and the details? =
+
+There is no setting for the color or font of parts in this plugin.
+My philosophy is that layout and code/content should be separated as much as possible.
+Furthermore, the plugin should seamlessly fit the style of the website and be fully customizable via CSS
+
+So for color and font, the settings of the theme are used and are then applied via CSS.
+But you can give each element within the plugin its own style (such as color and font size) from the theme via CSS.
+
+If you know your theme css well and it contains classes you want to use on these fields you can add those class-names in
+the Advanced settings: "SUFFIX GROUP CLASS:", "SUFFIX EVENT START CLASS:" and "SUFFIX EVENT DETAILS CLASS:"
+
+Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most themes.   
+IMPORTANT:   
+In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in "HTML ANCHOR", for example “Simple-ical-Block-1” the code translated into a high-level ID of the block.
+With the next block of additional CSS you can make the Dates red and 24 px, the Summary blue and 16 px,
+and the Details green with a gray background.
+
+```
+/*additional CSS for Simple-ical-Block-1 */
+#Simple-ical-Block-1 .ical-date {
+color: #ff0000;
+font-size: 24px;
+}
+#Simple-ical-Block-1 .ical_summary {
+color: #0000ff;
+font-size: 16px;
+}
+#Simple-ical-Block-1 .ical_details {
+color: #00ff00;
+background-color: gray;
+font-size: 16px;
+}
+/*end additional CSS for Simple-ical-Block-1 */
+```
+
 = How do I contribute to Simple Google Calendar Outlook Events Widget? =
 
 We'd love your help! Here's a few things you can do:

--- a/README.md
+++ b/README.md
@@ -135,31 +135,31 @@ So for color and font, the settings of the theme are used and are then applied v
 But you can give each element within the plugin its own style (such as color and font size) from the theme via CSS.
 
 If you know your theme css well and it contains classes you want to use on these fields you can add those class-names in
-the Advanced settings: "SUFFIX GROUP CLASS:", "SUFFIX EVENT START CLASS:" and "SUFFIX EVENT DETAILS CLASS:"
+the Advanced settings: &#34;SUFFIX GROUP CLASS:&#34;, &#34;SUFFIX EVENT START CLASS:&#34; and &#34;SUFFIX EVENT DETAILS CLASS:&#34;
 
 Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most themes.   
 IMPORTANT:   
-In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in "HTML ANCHOR", for example “Simple-ical-Block-1” the code translated into a high-level ID of the block.
+In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in &#34;HTML ANCHOR&#34;, for example &#39;Simple-ical-Block-1&#39; the code translated into a high-level ID of the block.
 With the next block of additional CSS you can make the Dates red and 24 px, the Summary blue and 16 px,
 and the Details green with a gray background.
 
-```
+~~~
 /*additional CSS for Simple-ical-Block-1 */
-#Simple-ical-Block-1 .ical-date {
+&#35;Simple-ical-Block-1 .ical-date {
 color: #ff0000;
 font-size: 24px;
 }
-#Simple-ical-Block-1 .ical_summary {
+&#35;Simple-ical-Block-1 .ical_summary {
 color: #0000ff;
 font-size: 16px;
 }
-#Simple-ical-Block-1 .ical_details {
+&#35;Simple-ical-Block-1 .ical_details {
 color: #00ff00;
 background-color: gray;
 font-size: 16px;
 }
 /*end additional CSS for Simple-ical-Block-1 */
-```
+~~~
 
 = How do I contribute to Simple Google Calendar Outlook Events Widget? =
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,8 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 
 == Changelog ==
 * 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
-' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
+' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.  
+Parse Recurrence-ID to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.
 * 2.1.5 20230824 after an issue of johansam (@johansam) in wp support forum: 'Warning: Undefined array key
 ' reviewed and improved initialising of options for legacy widget.
 * 2.1.4 20230725 tested with WordPress 6.3-RC1 running Twenty Twenty-Two theme.    

--- a/README.md
+++ b/README.md
@@ -205,7 +205,8 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 == Changelog ==
 * 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
 ' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.  
-Parse Recurrence-ID to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.
+Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.  
+Add help text's in block settings panel.
 * 2.1.5 20230824 after an issue of johansam (@johansam) in wp support forum: 'Warning: Undefined array key
 ' reviewed and improved initialising of options for legacy widget.
 * 2.1.4 20230725 tested with WordPress 6.3-RC1 running Twenty Twenty-Two theme.    

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
 ' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.  
 Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.  
+Changed textdomain from simple_ical to simple-google-icalendar-widget to make translations work by following the WP standard.  
 Add help text's in block settings panel.
 * 2.1.5 20230824 after an issue of johansam (@johansam) in wp support forum: 'Warning: Undefined array key
 ' reviewed and improved initialising of options for legacy widget.

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Theoretically this could als happen with recurrent events in the same timezone w
 Test results and comparison with Google and Outlook calendar have been uploaded as DayLightSavingTime test.xlsx.
   
 === From the ical specifications ===
+
 ~~~
 see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
 or https://icalendar.org/iCalendar-RFC-5545/
@@ -224,6 +225,7 @@ or https://icalendar.org/iCalendar-RFC-5545/
              special expand for MONTHLY if BYMONTH present; otherwise,
              special expand for YEARLY.
 ~~~
+
 (This widget is a Fork of version 0.7 of that simple google calendar widget by NBoehr
 https://nl.wordpress.org/plugins/simple-google-calendar-widget/)
 

--- a/README.txt
+++ b/README.txt
@@ -125,6 +125,42 @@ Check if you can download the ics file you have designated in the widget with a 
 
  Yes you can, since v1.2.0, I have tested with [https://p24-calendars.icloud.com/holiday/NL_nl.ics](https://p24-calendars.icloud.com/holiday/NL_nl.ics) .
 
+= How do I set different colours and text size for the dates, the summary, and the details? =
+
+There is no setting for the color or font of parts in this plugin.
+My philosophy is that layout and code/content should be separated as much as possible.
+Furthermore, the plugin should seamlessly fit the style of the website and be fully customizable via CSS
+
+So for color and font, the settings of the theme are used and are then applied via CSS.
+But you can give each element within the plugin its own style (such as color and font size) from the theme via CSS.
+
+If you know your theme css well and it contains classes you want to use on these fields you can add those class-names in
+the Advanced settings: "SUFFIX GROUP CLASS:", "SUFFIX EVENT START CLASS:" and "SUFFIX EVENT DETAILS CLASS:"
+
+Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most themes.   
+IMPORTANT:   
+In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in "HTML ANCHOR", for example “Simple-ical-Block-1” the code translated into a high-level ID of the block.
+With the next block of additional CSS you can make the Dates red and 24 px, the Summary blue and 16 px,
+and the Details green with a gray background.
+
+```
+/*additional CSS for Simple-ical-Block-1 */
+#Simple-ical-Block-1 .ical-date {
+color: #ff0000;
+font-size: 24px;
+}
+#Simple-ical-Block-1 .ical_summary {
+color: #0000ff;
+font-size: 16px;
+}
+#Simple-ical-Block-1 .ical_details {
+color: #00ff00;
+background-color: gray;
+font-size: 16px;
+}
+/*end additional CSS for Simple-ical-Block-1 */
+```
+
 = How do I contribute to Simple Google Calendar Outlook Events Widget? =
 
 We'd love your help! Here's a few things you can do:
@@ -144,7 +180,7 @@ We'd love your help! Here's a few things you can do:
 * End of repeating by COUNT or UNTIL
 * By day month, monthday or setpos (BYDAY, BYMONTH, BYMONTHDAY, BYSETPOS) no other by...   
   (not parsed: BYWEEKNO, BYYEARDAY, BYHOUR, BYMINUTE, RDATE)
-* Exclude events on EXDATE from repeat (after evaluating BYSETPOS)
+* Exclude events on EXDATE from recurrence set (after evaluating BYSETPOS)
 * Respects Timezone and Day Light Saving time. Build and tested with Iana timezones as used in php, Google, and Apple now also tested with Microsoft timezones and unknown timezones. For unknown timezone-names using the default timezone of Wordpress (probably the local timezone).  
 
 === Recurrent events, Timezone,  Daylight Saving Time ===
@@ -166,6 +202,7 @@ Test results and comparison with Google and Outlook calendar have been uploaded 
 === From the ical specifications ===
 ~~~
 see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
+or https://icalendar.org/iCalendar-RFC-5545/
 (see 3.3.10. [Page 38] Recurrence Rule in specification
   .____________._________.________._________.________.
   |            |DAILY    |WEEKLY  |MONTHLY  |YEARLY  |
@@ -202,9 +239,13 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * since v1.2.0 Wordpress version 5.3.0 is required because of the use of wp_date() 
 
 == Changelog ==
-* 20231104 tested with 6.4-RC3.
+* 2.2.0 after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events
+' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.  
+Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.  
+Changed textdomain from simple_ical to simple-google-icalendar-widget to make translations work by following the WP standard.  
+Add help text's in block settings panel.
 * 2.1.5 20230824 after an issue of johansam (@johansam) in wp support forum: 'Warning: Undefined array key
-' reviewed and improved initialising of options for legacy widget.   
+' reviewed and improved initialising of options for legacy widget.
 * 2.1.4 20230725 tested with WordPress 6.3-RC1 running Twenty Twenty-Two theme.    
 20230626 added quotes to the options of the Layout SelectControl in simple-ical-block.js conform / Block Editor Handbook / Reference Guides / Component Reference / SelectControl to emphasize that the return value is a string;   
 To make transform smoother: Add parseInt to all integers in transform and added missing transformations in block.js     

--- a/README.txt
+++ b/README.txt
@@ -135,31 +135,31 @@ So for color and font, the settings of the theme are used and are then applied v
 But you can give each element within the plugin its own style (such as color and font size) from the theme via CSS.
 
 If you know your theme css well and it contains classes you want to use on these fields you can add those class-names in
-the Advanced settings: "SUFFIX GROUP CLASS:", "SUFFIX EVENT START CLASS:" and "SUFFIX EVENT DETAILS CLASS:"
+the Advanced settings: &#34;SUFFIX GROUP CLASS:&#34;, &#34;SUFFIX EVENT START CLASS:&#34; and &#34;SUFFIX EVENT DETAILS CLASS:&#34;
 
 Otherwise you can add a block of additional CSS (or extra css or user css or something like that), which is possible with most themes.   
 IMPORTANT:   
-In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in "HTML ANCHOR", for example “Simple-ical-Block-1” the code translated into a high-level ID of the block.
+In order to target the CSS very specifically to the simple-ical-block, it is best to enter something unique in the settings of the block/widget under Advanced in &#34;HTML ANCHOR&#34;, for example &#39;Simple-ical-Block-1&#39; the code translated into a high-level ID of the block.
 With the next block of additional CSS you can make the Dates red and 24 px, the Summary blue and 16 px,
 and the Details green with a gray background.
 
-```
+~~~
 /*additional CSS for Simple-ical-Block-1 */
-#Simple-ical-Block-1 .ical-date {
+&#35;Simple-ical-Block-1 .ical-date {
 color: #ff0000;
 font-size: 24px;
 }
-#Simple-ical-Block-1 .ical_summary {
+&#35;Simple-ical-Block-1 .ical_summary {
 color: #0000ff;
 font-size: 16px;
 }
-#Simple-ical-Block-1 .ical_details {
+&#35;Simple-ical-Block-1 .ical_details {
 color: #00ff00;
 background-color: gray;
 font-size: 16px;
 }
 /*end additional CSS for Simple-ical-Block-1 */
-```
+~~~
 
 = How do I contribute to Simple Google Calendar Outlook Events Widget? =
 

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Plugin name: Simple Google Calendar Outlook Events Block Widget
 Contributors: bramwaas
 Tags: Event Calendar, Google Calendar, iCal, Events, Block, Calendar, iCalendar, Outlook, iCloud
 Requires at least: 5.3.0
-Tested up to: 6.3
+Tested up to: 6.4
 Requires PHP: 5.3.0
 Stable tag: trunk
 License: GPLv2 or later
@@ -202,6 +202,7 @@ This project is licensed under the [GNU GPL](http://www.gnu.org/licenses/old-lic
 * since v1.2.0 Wordpress version 5.3.0 is required because of the use of wp_date() 
 
 == Changelog ==
+* 20231104 tested with 6.4-RC3.
 * 2.1.5 20230824 after an issue of johansam (@johansam) in wp support forum: 'Warning: Undefined array key
 ' reviewed and improved initialising of options for legacy widget.   
 * 2.1.4 20230725 tested with WordPress 6.3-RC1 running Twenty Twenty-Two theme.    

--- a/README.txt
+++ b/README.txt
@@ -200,6 +200,7 @@ Theoretically this could als happen with recurrent events in the same timezone w
 Test results and comparison with Google and Outlook calendar have been uploaded as DayLightSavingTime test.xlsx.
   
 === From the ical specifications ===
+
 ~~~
 see http://www.ietf.org/rfc/rfc5545.txt for specification of te ical format.
 or https://icalendar.org/iCalendar-RFC-5545/
@@ -224,6 +225,7 @@ or https://icalendar.org/iCalendar-RFC-5545/
              special expand for MONTHLY if BYMONTH present; otherwise,
              special expand for YEARLY.
 ~~~
+
 (This widget is a Fork of version 0.7 of that simple google calendar widget by NBoehr
 https://nl.wordpress.org/plugins/simple-google-calendar-widget/)
 

--- a/block.json
+++ b/block.json
@@ -7,8 +7,8 @@
     "description": "Block that displays events from a public calendar or iCal file.",
     "keywords": [ "calendar", "ical", "event", "events", "google", "outlook", "iCalendar", "holydays", "ics" ],
     "icon": "calendar-alt",
-    "version": "2.1.3",
-    "textdomain": "simple_ical",
+    "version": "2.2.0",
+    "textdomain": "simple-google-icalendar-widget",
     "example": {"attributes": {
         "title": "Example events.",
         "calendar_id": "#example",

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -346,7 +346,7 @@ END:VCALENDAR';
                 if (empty($e->exdate) || !in_array($e->start, $e->exdate)) {
                    $this->events[] = $e;
                    if (!empty($e->recurid)){
-                       $this->$replaceevents[] = array($e->UID, $e->recurid );
+                       $this->replaceevents[] = array($e->UID, $e->recurid );
                    }
                 }
                 // Recurring event?
@@ -671,10 +671,12 @@ END:VCALENDAR';
                 && $e->start <= $this->penddate
                 ) {
                     if (!empty($this->replaceevents) && empty($e->recurid)){
-                        $a = explode ($e->uid, '_', 2);
-                        $e_uid = (count($a) > 1) ? $a[2] : $a[1];
-                        if (  !in_array(array($e_uid, $e->start ), $this->replaceevents)) {
-                            continue;
+                        $a = explode ('_', $e->uid, 2);
+                        $e_uid = (count($a) > 1) ? $a[1] : $a[0];
+                        $e->description = $e->description . '. e_uid= ' . $e_uid . '. $e->uid =' .$e->uid;
+                         if ( in_array(array($e_uid, $e->start ), $this->replaceevents, true)) {
+                            $e->description = "VERWIJDEREN " . $e_uid ;
+//TODO                            continue;
                         }
                     }
                     $i++;

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -669,7 +669,7 @@ END:VCALENDAR';
         foreach ($this->events as $e) {
             if (($e->end >= $this->now)
                 && $e->start <= $this->penddate
-                && (empty($this->replaceevents) || !in_array(array(explode($e->UID,'_',2 )[1], $e->start ), $this->replaceevents))
+                && (empty($this->replaceevents) || !empty($e->recurid) || !in_array(array(explode($e->UID,'_',2 )[1], $e->start ), $this->replaceevents))
                 ) {
                     $i++;
                     if ($i > $this->event_count) {

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -40,6 +40,7 @@
  *   Combined getFutureEvents and Limit array. usort eventsortcomparer now on start, end, cal_ord and with arithmic subtraction because all are integers.
  *   Parse event DURATION; (only) When DTEND is empty: determine end from start plus duration, when duration is empty and start is DATE start plus one day, else = start
  *   Parse event BYSETPOS; Parse WKST (default MO) 
+ * 2.2.0 improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
  */
 namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
 

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -336,7 +336,9 @@ END:VCALENDAR';
                 $e = $this->parseVevent($eventStr);
                 $e->cal_class = $cal_class;
                 $e->cal_ord = $cal_ord;
-                $this->events[] = $e;
+                if (!empty($e->exdate) || !in_array($newstart->getTimestamp(), $e->exdate)) {
+                   $this->events[] = $e;
+                }
                 // Recurring event?
                 if (isset($e->rrule) && $e->rrule !== '') {
                     /* Recurring event, parse RRULE in associative array add appropriate duplicate events

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -336,7 +336,7 @@ END:VCALENDAR';
                 $e = $this->parseVevent($eventStr);
                 $e->cal_class = $cal_class;
                 $e->cal_ord = $cal_ord;
-                if (!empty($e->exdate) || !in_array($newstart->getTimestamp(), $e->exdate)) {
+                if (empty($e->exdate) || !in_array($newstart->getTimestamp(), $e->exdate)) {
                    $this->events[] = $e;
                 }
                 // Recurring event?

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -25,21 +25,21 @@
  *   bw 20220407 Extra options for parser in array poptions and added temporary new option processdst to process differences in DST between start of series events and the current event.
  *   bw 20220408 v1.5.1 Namespaced and some restructuration of code. Add difference in seconds to timestamp newstart to get timestamp newend instead of working with DateInterval.
  *               This calculation better takes into account the deleted hour at the start of DST.
- *               Correction when time is changed by ST to DST transition set hour and minutes back to beginvalue (because time doesn't exist during changeperiod) 
+ *               Correction when time is changed by ST to DST transition set hour and minutes back to beginvalue (because time doesn't exist during changeperiod)
  *               Set event Timezoneid to UTC when datetimesting ends with Z (zero date)
- *   bw 20220527 V2.0.1 code starting with getData from block to this class 
- *   bw 20220613 v2.0.2 code to correct endtime (00:00:00) when recurring event with different start and end as dates includes DST to ST transition or vv  
+ *   bw 20220527 V2.0.1 code starting with getData from block to this class
+ *   bw 20220613 v2.0.2 code to correct endtime (00:00:00) when recurring event with different start and end as dates includes DST to ST transition or vv
  *   bw 20220613 v2.0.4 Improvements IcsParser made as a result of porting to Joomla
  * solve issue not recognizing http as a valid protocol in array('http', 'https', 'webcal') because index = 0 so added 1 as starting index
  * make timezone-string a property of the object filled with the time-zone setting of the CMS (get_option('timezone_string')).
- * replace wp_date() by date() because translation of weekday- and month-names is not needed.                   
+ * replace wp_date() by date() because translation of weekday- and month-names is not needed.
  * 2.1.0 calendar_id can be array of ID;class elements; elements foreach in fetch() to parse each element; sort moved to fetch() after foreach.
  *   parse() directly add in events in $this->events, add html-class from new input parameter to each event
  *   Make properties from most important parameters during instantiation of the class to limit copying of input params in several functions.
  *   Removed htmlspecialchars() from summary, description and location, to replace it in the output template/block
  *   Combined getFutureEvents and Limit array. usort eventsortcomparer now on start, end, cal_ord and with arithmic subtraction because all are integers.
  *   Parse event DURATION; (only) When DTEND is empty: determine end from start plus duration, when duration is empty and start is DATE start plus one day, else = start
- *   Parse event BYSETPOS; Parse WKST (default MO) 
+ *   Parse event BYSETPOS; Parse WKST (default MO)
  * 2.2.0 improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
  */
 namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
@@ -91,7 +91,7 @@ END:VCALENDAR';
      * @var array english abbreviations and names of weekdays.
      */
     private static $weekdays = array(
-         'MO' => 'monday',
+        'MO' => 'monday',
         'TU' => 'tuesday',
         'WE' => 'wednesday',
         'TH' => 'thursday',
@@ -319,7 +319,7 @@ END:VCALENDAR';
      *
      * @param   string      $str the  content of the file to parse as a string.
      * @param   string      $cal_class the html-class for this calendar
-     * @param   int         $cal_ord   order in list of this calendar 
+     * @param   int         $cal_ord   order in list of this calendar
      *
      * @return  array       $this->events the parsed event objects.
      *
@@ -344,10 +344,10 @@ END:VCALENDAR';
                 $e->cal_class = $cal_class;
                 $e->cal_ord = $cal_ord;
                 if (empty($e->exdate) || !in_array($e->start, $e->exdate)) {
-                   $this->events[] = $e;
-                   if (!empty($e->recurid)){
-                       $this->replaceevents[] = array($e->UID, $e->recurid );
-                   }
+                    $this->events[] = $e;
+                    if (!empty($e->recurid)){
+                        $this->replaceevents[] = array($e->uid, $e->recurid );
+                    }
                 }
                 // Recurring event?
                 if (isset($e->rrule) && $e->rrule !== '') {
@@ -390,7 +390,7 @@ END:VCALENDAR';
                     $edtendd->setTimezone($timezone);
                     $edurationsecs =  $e->end - $e->start;
                     $nowstart = $this->now - $edurationsecs -1;
-
+                    
                     $rrules = array();
                     $rruleStrings = explode(';', $e->rrule);
                     foreach ($rruleStrings as $s) {
@@ -418,7 +418,7 @@ END:VCALENDAR';
                             break;
                         case "WEEKLY"	:
                             $freqstartparse = $freqstartparse - 604800; // 7 days in sec
-                            $freqendloop = $until + 604800; 
+                            $freqendloop = $until + 604800;
                             break;
                         case "DAILY"	:
                             $freqstartparse = $freqstartparse - 86400; // 1 days in sec
@@ -638,14 +638,14 @@ END:VCALENDAR';
                             }
                             if  ($fmdayok &&
                                 in_array($frequency , array('MONTHLY', 'YEARLY')) &&
-                                $freqstart->format('j') !== $edtstartmday){ // monthday changed eg 31 jan + 1 month = 3 mar; 
+                                $freqstart->format('j') !== $edtstartmday){ // monthday changed eg 31 jan + 1 month = 3 mar;
                                     $freqstart->sub($interval3day);
                                     $fmdayok = false;
                             } elseif (!$fmdayok ){
                                 $freqstart->add($interval3day);
                                 $fmdayok = true;
-                        	}
-                        }  // end while $freqstart->getTimestamp() <= $freqendloop and $count ...
+                            }
+                            }  // end while $freqstart->getTimestamp() <= $freqendloop and $count ...
                     }
                 } // switch freq
                 //
@@ -656,14 +656,14 @@ END:VCALENDAR';
             }
         } while($haveVevent);
     }
-/*
- * Limit events to the first event_count events from today. 
- * Events are already sorted
- * 
- * @return  array       remaining event objects.
- */
+    /*
+     * Limit events to the first event_count events from today.
+     * Events are already sorted
+     *
+     * @return  array       remaining event objects.
+     */
     public function getFutureEvents( ) {
-        // 
+        //
         $newEvents = array();
         $i=0;
         foreach ($this->events as $e) {
@@ -673,10 +673,13 @@ END:VCALENDAR';
                     if (!empty($this->replaceevents) && empty($e->recurid)){
                         $a = explode ('_', $e->uid, 2);
                         $e_uid = (count($a) > 1) ? $a[1] : $a[0];
-                        $e->description = $e->description . '. e_uid= ' . $e_uid . '. $e->uid =' .$e->uid;
-                         if ( in_array(array($e_uid, $e->start ), $this->replaceevents, true)) {
+                        $e->description = $e->description . '. e_uid= ' . $e_uid . '. $e->uid =' .$e->uid . 'repevents:';
+                        foreach ($this->replaceevents as $re){
+                            $e->description = $e->description . '<br>rUID:' . $re[0] . 'rDate:' . $re[1];
+                        }
+                        if ( in_array(array($e_uid, $e->start ), $this->replaceevents, true)) {
                             $e->description = "VERWIJDEREN " . $e_uid ;
-//TODO                            continue;
+                            //TODO                            continue;
                         }
                     }
                     $i++;
@@ -694,11 +697,11 @@ END:VCALENDAR';
         return $this->events;
     }
     /*
-    * Parse timestamp from date time string (with timezone ID)
-    * @param  string $datetime date time format YYYYMMDDTHHMMSSZ last letter ='Z' means Zero-time or 'UTC' time. overrides any timezone.
-    * @param  string $ptzid (timezone ID)
-    * @return int timestamp
-    */
+     * Parse timestamp from date time string (with timezone ID)
+     * @param  string $datetime date time format YYYYMMDDTHHMMSSZ last letter ='Z' means Zero-time or 'UTC' time. overrides any timezone.
+     * @param  string $ptzid (timezone ID)
+     * @return int timestamp
+     */
     
     private function parseIcsDateTime($datetime, $tzid = '') {
         if (strlen($datetime) < 8) {
@@ -721,7 +724,7 @@ END:VCALENDAR';
         $date = \DateTime::createFromFormat('Ymd His e', substr($datetime,0,8) . ' ' . $hms. ' ' . $tzid);
         $timestamp = $date->getTimestamp();
         return $timestamp;
-    } 
+    }
     /**
      * Checks if a time zone is a recognised Windows (non-CLDR) time zone
      *
@@ -773,7 +776,7 @@ END:VCALENDAR';
         if ($a->start == $b->start) {
             if ($a->end == $b->end) {
                 return ($a->cal_ord - $b->cal_ord);
-            } 
+            }
             else return ($a->end - $b->end);
         }
         else return ($a->start - $b->start);
@@ -873,7 +876,7 @@ END:VCALENDAR';
                         $eventObj->recurid = $this->parseIcsDateTime($value, $tzid);
                         break;
                 }
-             }else { // count($list) <= 1
+            }else { // count($list) <= 1
                 if (strlen($l) > 1) {
                     $desc = str_replace(array('\;', '\,', '\r\n','\n', '\r'), array(';', ',', "\n","\n","\n"), substr($l,1));
                     switch($tokenprev) {
@@ -938,7 +941,7 @@ END:VCALENDAR';
         return $data;
     }
     /**
-     * Fetches from calender using calendar_ids, event_count and 
+     * Fetches from calender using calendar_ids, event_count and
      *
      *    ['calendar_id']  id or url of the calender to fetch data
      *    ['event_count']  max number of events to return
@@ -956,32 +959,32 @@ END:VCALENDAR';
             $cal_class = (isset($calary[1])) ?trim($calary[1]," \n\r\t\v\x00\x22"): '';
             ++$cal_ord;
             if ('#example' == $cal_id){
-	            $httpBody = self::$example_events;
-	        }
-	        else  {
+                $httpBody = self::$example_events;
+            }
+            else  {
                 $url = self::getCalendarUrl($cal_id);
-	            $httpData = wp_remote_get($url);
-	            if(is_wp_error($httpData)) {
-	                echo '<!-- ' . $url . ' not found ' . 'fall back to https:// -->';
-	                $httpData = wp_remote_get('https://' . explode('://', $url)[1]);
-	                if(is_wp_error($httpData)) {
-	                    echo '<!-- Simple iCal Block: ', $httpData->get_error_message(), ' -->';
-	                    continue;
-	                }
-	            }
-		        if(is_array($httpData) && array_key_exists('body', $httpData)) {
- 	           		$httpBody = $httpData['body'];
-		        } else continue;
-	        }
-	        
-        
-	        try {
+                $httpData = wp_remote_get($url);
+                if(is_wp_error($httpData)) {
+                    echo '<!-- ' . $url . ' not found ' . 'fall back to https:// -->';
+                    $httpData = wp_remote_get('https://' . explode('://', $url)[1]);
+                    if(is_wp_error($httpData)) {
+                        echo '<!-- Simple iCal Block: ', $httpData->get_error_message(), ' -->';
+                        continue;
+                    }
+                }
+                if(is_array($httpData) && array_key_exists('body', $httpData)) {
+                    $httpBody = $httpData['body'];
+                } else continue;
+            }
+            
+            
+            try {
                 $this->parse($httpBody,  $cal_class, $cal_ord );
- 	        } catch(\Exception $exc) {
-	            continue;
-	        }
+            } catch(\Exception $exc) {
+                continue;
+            }
         } // end foreach
-
+        
         usort($this->events, array($this, "eventSortComparer"));
         return $this->getFutureEvents();
     }
@@ -991,7 +994,7 @@ END:VCALENDAR';
         $protocol = strtolower(explode('://', $calId)[0]);
         if (array_search($protocol, array(1 => 'http', 'https', 'webcal')))
         { if ('webcal' == $protocol) $calId = 'http://' . explode('://', $calId)[1];
-           return $calId; }
+        return $calId; }
         else
         { return 'https://www.google.com/calendar/ical/'.$calId.'/public/basic.ics'; }
     }

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -43,7 +43,7 @@
  * 2.2.0 improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
  *   Parse Recurrence-ID to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID. 
  */
-namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
+namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget;
 
 class IcsParser {
     

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -835,6 +835,14 @@ END:VCALENDAR';
                             $eventObj->exdate[] = $this->parseIcsDateTime($value, $tzid);
                         }
                         break;
+// not implemented yet                        
+//                     case "RDATE":
+//                         $dtl = explode(",", $value);
+//                         foreach ($dtl as $value) {
+//                             $eventObj->rdate[] = $this->parseIcsPeriodOrDateTime($value, $tzid);
+//                         }
+//                         break;
+// PERIOD = period-explicit OR period-start; period-explicit = date-time "/" date-time;  period-start = date-time "/" dur-value
                 }
             }else { // count($list) <= 1
                 if (strlen($l) > 1) {

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -592,7 +592,7 @@ END:VCALENDAR';
                                             ($fmdayok || $expand)
                                             && ($count == 0 || $i < $count)
                                             && $newstart->getTimestamp() <= $until
-                                            && !(!empty($e->exdate) && in_array($newstart->getTimestamp(), $e->exdate))
+                                            && (empty($e->exdate) || !in_array($newstart->getTimestamp(), $e->exdate))
                                             && $newstart> $edtstart) { // count events after dtstart
                                                 if ($newstart->getTimestamp() > $nowstart
                                                     ) { // copy only events after now
@@ -950,7 +950,7 @@ END:VCALENDAR';
         
 	        try {
                 $this->parse($httpBody,  $cal_class, $cal_ord );
- 	        } catch(\Exception $e) {
+ 	        } catch(\Exception $exc) {
 	            continue;
 	        }
         } // end foreach

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -336,7 +336,7 @@ END:VCALENDAR';
                 $e = $this->parseVevent($eventStr);
                 $e->cal_class = $cal_class;
                 $e->cal_ord = $cal_ord;
-                if (empty($e->exdate) || !in_array($newstart->getTimestamp(), $e->exdate)) {
+                if (empty($e->exdate) || !in_array($e->start, $e->exdate)) {
                    $this->events[] = $e;
                 }
                 // Recurring event?

--- a/includes/IcsParser.php
+++ b/includes/IcsParser.php
@@ -669,8 +669,14 @@ END:VCALENDAR';
         foreach ($this->events as $e) {
             if (($e->end >= $this->now)
                 && $e->start <= $this->penddate
-                && (empty($this->replaceevents) || !empty($e->recurid) || !in_array(array(explode($e->UID,'_',2 )[1], $e->start ), $this->replaceevents))
                 ) {
+                    if (!empty($this->replaceevents) && empty($e->recurid)){
+                        $a = explode ($e->uid, '_', 2);
+                        $e_uid = (count($a) > 1) ? $a[2] : $a[1];
+                        if (  !in_array(array($e_uid, $e->start ), $this->replaceevents)) {
+                            continue;
+                        }
+                    }
                     $i++;
                     if ($i > $this->event_count) {
                         break;

--- a/includes/SimpleicalBlock.php
+++ b/includes/SimpleicalBlock.php
@@ -9,24 +9,24 @@
  * @link       https://github.com/bramwaas/wordpress-plugin-wsa-simple-google-calendar-widget
  * @license    http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
  * Gutenberg Block functions since v2.1.2 also used for widget.
- * Version: 2.1.5
+ * Version: 2.2.0
  * 20220427 namespaced and renamed after classname.
  * 20220430 try with static calls
  * 20220509 fairly correct front-end display. attributes back to block.json
  * 20220510 attributes again in php also added anchor, align and className who can be added by support hopefully that is enough for ServerSideRender.
  * 20220511 integer excerptlength not initialised with '' because serversiderender REST type validation gives an error (rest_invalid_type)
- *  excerptlength string and in javascript  '' when not parsed as integer. 
- * 20220526 added example 
+ *  excerptlength string and in javascript  '' when not parsed as integer.
+ * 20220526 added example
  * 20220620 added enddate/times for startdate and starttime added Id as anchor and choice of tagg for summary, collaps only when tag_for summary = a.
  * 2.1.0 add calendar class to list-group-item
  *   add htmlspecialchars() to summary, description and location when not 'allowhtml', replacing similar code from IcsParser
  * 2.1.1 20230401 use select 'layout' in stead of 'start with summary' to create more lay-out options.
  * 2.1.2 20230410 move assignment of cal_class to a place where e=>cal_class is available.
  * 2.1.3 20230418 Added optional placeholder HTML output when no upcoming events are avalable. Also added optional output after the events list (when upcoming events are available).
- * 2.1.5 20230824 default_block_attributes as static variable and alowed_tags_sum made public to use same values also in the widget, option anchorId moved to render_block. 
- * 
+ * 2.1.5 20230824 default_block_attributes as static variable and alowed_tags_sum made public to use same values also in the widget, option anchorId moved to render_block.
+ * 2.2.0 20240106 changed text domain to simple-google-icalendar-widget
  */
-namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
+namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget;
 
 class SimpleicalBlock {
     /**
@@ -38,11 +38,11 @@ class SimpleicalBlock {
      * deafault value for block_attributes (or instance)
      * @var array
      */
-     static $default_block_attributes =   array(
+    static $default_block_attributes =   array(
         'wptype' => 'block',
         'blockid' => 'AZ',
-//         'title' => __('Events', 'simple_ical'),
-         'calendar_id' => '',
+        //         'title' => __('Events', 'simple-google-icalendar-widget'),
+        'calendar_id' => '',
         'event_count' => 10,
         'event_period' => 92,
         'cache_time' => 60,
@@ -64,7 +64,7 @@ class SimpleicalBlock {
         'clear_cache_now' => false,
         'className'=>'',
         'anchorId'=> '',
-        );
+    );
     
     /**
      * Block init register block with help of block.json
@@ -74,59 +74,59 @@ class SimpleicalBlock {
     static function init_block() {
         register_block_type( dirname(__DIR__) .'/block.json',
             array(
-        'attributes' => [
-            'wptype' => ['type' => 'string'],
-            'blockid' => ['type' => 'string'],
-            'title' => ['type' => 'string', 'default' => __('Events', 'simple_ical')],
-            'calendar_id' => ['type' => 'string', 'default' => ''],
-            'event_count' => ['type' => 'integer', 'default' => 10],
-            'event_period' => ['type' => 'integer', 'default' => 92],
-            'layout' => ['type' => 'integer', 'default' => 3],
-            'cache_time' => ['type' => 'integer', 'default' => 60],
-            'dateformat_lg' => ['type' => 'string', 'default' => 'l jS \of F'],
-            'dateformat_lgend' => ['type' => 'string', 'default' => ''],
-            'tag_sum' => ['type' => 'string', 'enum' => self::$allowed_tags_sum, 'default' => 'a'],
-            'dateformat_tsum' => ['type' => 'string', 'default' => 'G:i '],
-            'dateformat_tsend' => ['type' => 'string', 'default' => ''],
-            'dateformat_tstart' => ['type' => 'string', 'default' => 'G:i'],
-            'dateformat_tend' => ['type' => 'string', 'default' => ' - G:i '],
-            'excerptlength' => ['type' => 'string', ''],
-            'suffix_lg_class' => ['type' => 'string', 'default' => ''],
-            'suffix_lgi_class' => ['type' => 'string', 'default' => ' py-0'],
-            'suffix_lgia_class' => ['type' => 'string', 'default' => ''],
-            'allowhtml' => ['type' => 'boolean', 'default' => false],
-            'after_events' => ['type' => 'string', 'default' => ''],
-            'no_events' => ['type' => 'string', 'default' => ''],
-            'clear_cache_now' => ['type' => 'boolean', 'default' => false],
-            'anchorId' => ['type' => 'string', 'default' => ''],
-        ],
-            'render_callback' => array('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalBlock', 'render_block'))
-        );
-   }
+                'attributes' => [
+                    'wptype' => ['type' => 'string'],
+                    'blockid' => ['type' => 'string'],
+                    'title' => ['type' => 'string', 'default' => __('Events', 'simple-google-icalendar-widget')],
+                    'calendar_id' => ['type' => 'string', 'default' => ''],
+                    'event_count' => ['type' => 'integer', 'default' => 10],
+                    'event_period' => ['type' => 'integer', 'default' => 92],
+                    'layout' => ['type' => 'integer', 'default' => 3],
+                    'cache_time' => ['type' => 'integer', 'default' => 60],
+                    'dateformat_lg' => ['type' => 'string', 'default' => 'l jS \of F'],
+                    'dateformat_lgend' => ['type' => 'string', 'default' => ''],
+                    'tag_sum' => ['type' => 'string', 'enum' => self::$allowed_tags_sum, 'default' => 'a'],
+                    'dateformat_tsum' => ['type' => 'string', 'default' => 'G:i '],
+                    'dateformat_tsend' => ['type' => 'string', 'default' => ''],
+                    'dateformat_tstart' => ['type' => 'string', 'default' => 'G:i'],
+                    'dateformat_tend' => ['type' => 'string', 'default' => ' - G:i '],
+                    'excerptlength' => ['type' => 'string', ''],
+                    'suffix_lg_class' => ['type' => 'string', 'default' => ''],
+                    'suffix_lgi_class' => ['type' => 'string', 'default' => ' py-0'],
+                    'suffix_lgia_class' => ['type' => 'string', 'default' => ''],
+                    'allowhtml' => ['type' => 'boolean', 'default' => false],
+                    'after_events' => ['type' => 'string', 'default' => ''],
+                    'no_events' => ['type' => 'string', 'default' => ''],
+                    'clear_cache_now' => ['type' => 'boolean', 'default' => false],
+                    'anchorId' => ['type' => 'string', 'default' => ''],
+                ],
+                'render_callback' => array('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalBlock', 'render_block'))
+            );
+    }
     /**
      * Render the content of the block
      *
-     * see 
+     * see
      *
      * @param array $block_attributes the block attributes (that are changed from default therefore first merged with defaults.)
      * @param array $content as saved in post by save in ...block.js
      * @return string  HTML to render for the block (frontend)
      */
-   static function render_block($block_attributes, $content) {
-       $block_attributes = wp_parse_args((array) $block_attributes,
-           (array ('title' => __('Events', 'simple_ical')) + self::$default_block_attributes));
-       $block_attributes['anchorId'] = sanitize_html_class($block_attributes['anchorId'], $block_attributes['blockid']);
-       
-       $output = '';
-       ob_start();
-       self::display_block($block_attributes);
-       $output = $output . ob_get_clean();
-       return '<div id="' . $block_attributes['anchorId'] .'" class="' . $block_attributes['className'] . ((isset($block_attributes['align'])) ? (' align' . $block_attributes['align']) : ' ') .'" data-sib-id="' . $block_attributes['blockid'] . '" >' . $output . '</div>';
-   }
+    static function render_block($block_attributes, $content) {
+        $block_attributes = wp_parse_args((array) $block_attributes,
+            (array ('title' => __('Events', 'simple-google-icalendar-widget')) + self::$default_block_attributes));
+        $block_attributes['anchorId'] = sanitize_html_class($block_attributes['anchorId'], $block_attributes['blockid']);
+        
+        $output = '';
+        ob_start();
+        self::display_block($block_attributes);
+        $output = $output . ob_get_clean();
+        return '<div id="' . $block_attributes['anchorId'] .'" class="' . $block_attributes['className'] . ((isset($block_attributes['align'])) ? (' align' . $block_attributes['align']) : ' ') .'" data-sib-id="' . $block_attributes['blockid'] . '" >' . $output . '</div>';
+    }
     /**
      * Front-end display of block or widget.
      *
-     * @see 
+     * @see
      *
      * @param array $instance Saved attribute/option values from database.
      */
@@ -157,7 +157,7 @@ class SimpleicalBlock {
             $curdate = '';
             foreach($data as $e) {
                 $idlist = explode("@", esc_attr($e->uid) );
-                $itemid = $instance['blockid'] .'_' . strval(++$sn) . '_' . $idlist[0]; 
+                $itemid = $instance['blockid'] .'_' . strval(++$sn) . '_' . $idlist[0];
                 $evdate = wp_kses(wp_date( $dflg, $e->start), 'post');
                 $cal_class = ((!empty($e->cal_class)) ? ' ' . sanitize_html_class($e->cal_class): '');
                 if ( !$instance['allowhtml']) {
@@ -172,15 +172,15 @@ class SimpleicalBlock {
                 if ($layout < 2 && $curdate != $evdate) {
                     if  ($curdate != '') { echo '</ul></li>';}
                     echo '<li class="list-group-item' .  $sflgi . ' head">' .
-                    '<span class="ical-date">' . ucfirst($evdate) . '</span><ul class="list-group' .  $instance['suffix_lg_class'] . '">';
+                        '<span class="ical-date">' . ucfirst($evdate) . '</span><ul class="list-group' .  $instance['suffix_lg_class'] . '">';
                 }
                 echo '<li class="list-group-item' .  $sflgi . $cal_class . '">';
                 if ($layout == 3 && $curdate != $evdate) {
                     echo '<span class="ical-date">' . ucfirst($evdate) . '</span>' . (('a' == $instance['tag_sum'] ) ? '<br>': '');
                 }
                 echo  '<' . $instance['tag_sum'] . ' class="ical_summary' .  $sflgia . (('a' == $instance['tag_sum'] ) ? '" data-toggle="collapse" data-bs-toggle="collapse" href="#'.
-                $itemid . '" aria-expanded="false" aria-controls="'.
-                $itemid . '">' : '">') ;
+                    $itemid . '" aria-expanded="false" aria-controls="'.
+                    $itemid . '">' : '">') ;
                 if ($layout != 2)	{
                     echo $evdtsum;
                 }

--- a/includes/SimpleicalWidgetAdmin.php
+++ b/includes/SimpleicalWidgetAdmin.php
@@ -6,15 +6,16 @@
  * @package    Simple Google iCalendar Widget
  * @subpackage Admin
  * @author     Bram Waasdorp <bram@waasdorpsoekhan.nl>
- * @copyright  Copyright (c)  2017 - 2023, Bram Waasdorp
+ * @copyright  Copyright (c)  2017 - 2024, Bram Waasdorp
  * @link       https://github.com/bramwaas/wordpress-plugin-wsa-simple-google-calendar-widget
  * @license    http://www.gnu.org/licenses/old-licenses/gpl-2.0.html
- * Version: 2.1.3
+ * Version: 2.2.0
  * 20220410 namespaced and renamed after classname.
  * 2.1.0 option for comma seperated list of IDs
  * 2.1.3 block footer after events and placeholder when no events.
+ * 2.2.0 fix spell-error in namespace, and use new correct text domain
  */
-namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget;
+namespace WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget;
 
 class SimpleicalWidgetAdmin {
     //menu items
@@ -30,8 +31,8 @@ class SimpleicalWidgetAdmin {
         //ther is no main menu item for simple_ical
         //this submenu is HIDDEN, however, we need to add it to create a page in the admin area
         add_submenu_page(null, //parent slug
-            __('Info', 'simple_ical'), //page title
-            __('Info', 'simple_ical'), //menu title
+            __('Info', 'simple-google-icalendar-widget'), //page title
+            __('Info', 'simple-google-icalendar-widget'), //menu title
             'read', //capability read because it 's only info
             'simple_ical_info', //menu slug
             //			'simple_ical_info'); //function
@@ -48,83 +49,83 @@ class SimpleicalWidgetAdmin {
     public function simple_ical_info () {
         //
         echo('<div class="wrap">');
-        _e('<h2>Info on Simple Google Calendar Outlook Events Block Widget</h2>', 'simple_ical');
+        _e('<h2>Info on Simple Google Calendar Outlook Events Block Widget</h2>', 'simple-google-icalendar-widget');
         _e('<h3>Settings for this block/widget: </h3>' );
         
-        _e('<p><strong>Title</strong></p>', 'simple_ical');
-        _e('<p>Title of this instance of the widget</p>', 'simple_ical');
+        _e('<p><strong>Title</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Title of this instance of the widget</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Calendar ID(s), or iCal URL</strong></p>', 'simple_ical');
-        _e('<p>The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID&apos;s.</p>', 'simple_ical');
-        _e('<p>You can use #example to get example events</p>', 'simple_ical');
-        _e('<p>Or a comma separated list of ID&apos;s; optional you can add a html-class separated by a semicolon to some or all ID&apos;s to distinguish the descent in the lay-out of the event.</p>', 'simple_ical');
+        _e('<p><strong>Calendar ID(s), or iCal URL</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID&apos;s.</p>', 'simple-google-icalendar-widget');
+        _e('<p>You can use #example to get example events</p>', 'simple-google-icalendar-widget');
+        _e('<p>Or a comma separated list of ID&apos;s; optional you can add a html-class separated by a semicolon to some or all ID&apos;s to distinguish the descent in the lay-out of the event.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Number of events displayed</strong></p>', 'simple_ical');
-        _e('<p>The maximum number of events to display.</p>', 'simple_ical');
+        _e('<p><strong>Number of events displayed</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>The maximum number of events to display.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Number of days after today with events displayed</strong></p>', 'simple_ical');
-        _e('<p>Last date to display events in number of days after today.</p>', 'simple_ical');
+        _e('<p><strong>Number of days after today with events displayed</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Last date to display events in number of days after today.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Select lay-out</strong></p>', 'simple_ical');
-        _e('<p>Startdate line on a higher level in the list; Start with summary before first date line; Old style, summary after first date line, remove duplicate date lines.</p>', 'simple_ical');
+        _e('<p><strong>Select lay-out</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Startdate line on a higher level in the list; Start with summary before first date line; Old style, summary after first date line, remove duplicate date lines.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Date format first line</strong></p>', 'simple_ical');
-        _e('<p>Start date format first (date) line. Default: l jS \of F,<br>l = day of the week (Monday); j =  day of the month (25) F = name of month (december)<br>y or Y = Year (17 or 2017);<br>make empty if you don\'t want to show this date.<br>Although this is intended for date all date and time fields contain date and time so you can als use time formats in date fields and date formats in time field<br>You can also use other text or simple html tags to embellish or emphasize it<br>escape characters with special meaning with a slash(\) e.g.:&lt;\b&gt;\F\r\o\m l jS \of F.&lt;/\b&gt;<br>see also https://www.php.net/manual/en/datetime.format.php .</p>', 'simple_ical');
+        _e('<p><strong>Date format first line</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Start date format first (date) line. Default: l jS \of F,<br>l = day of the week (Monday); j =  day of the month (25) F = name of month (december)<br>y or Y = Year (17 or 2017);<br>make empty if you don\'t want to show this date.<br>Although this is intended for date all date and time fields contain date and time so you can als use time formats in date fields and date formats in time field<br>You can also use other text or simple html tags to embellish or emphasize it<br>escape characters with special meaning with a slash(\) e.g.:&lt;\b&gt;\F\r\o\m l jS \of F.&lt;/\b&gt;<br>see also https://www.php.net/manual/en/datetime.format.php .</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>End date format first line</strong></p>', 'simple_ical');
-        _e('<p>End date format first (date) line. Default: empty, no display.<br>End date will only be shown as date part is different from start date and format not empty.</p>', 'simple_ical');
+        _e('<p><strong>End date format first line</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>End date format first (date) line. Default: empty, no display.<br>End date will only be shown as date part is different from start date and format not empty.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Time format start time after summary</strong></p>', 'simple_ical');
-        _e('<p>Start time format summary line. Default: G:i ,<br>G or g = 24 or 12 hour format of an hour without leading zeros<br>i = Minutes with leading zeros<br>a or A = Lowercase or Uppercase Ante meridiem and Post meridiem<br>make empty if you don\'t want to show this field.<br>Linebreak before this field will be removed when summary is before first date line, if desired you can get it back by starting the format with &lt;\b\r&gt;<br>This field will only be shown when date part of enddate is equal to start date and format not empty.</p>', 'simple_ical');
+        _e('<p><strong>Time format start time after summary</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Start time format summary line. Default: G:i ,<br>G or g = 24 or 12 hour format of an hour without leading zeros<br>i = Minutes with leading zeros<br>a or A = Lowercase or Uppercase Ante meridiem and Post meridiem<br>make empty if you don\'t want to show this field.<br>Linebreak before this field will be removed when summary is before first date line, if desired you can get it back by starting the format with &lt;\b\r&gt;<br>This field will only be shown when date part of enddate is equal to start date and format not empty.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Time format end time after summary</strong></p>', 'simple_ical');
-        _e('<p>End time format summary line. Default: empty , no display.</p>', 'simple_ical');
+        _e('<p><strong>Time format end time after summary</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>End time format summary line. Default: empty , no display.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Time format start time</strong></p>', 'simple_ical');
-        _e('<p>Time format start time. Default: G:i,<br>G or g = 24 or 12 hour format of an hour without leading zeros<br>i = Minutes with leading zeros<br>a or A = Lowercase or Uppercase Ante meridiem and Post meridiem<br>make empty if you don\'t want to show start time.<br>You can also use other text to embellish it<br>escape characters with special meaning with a slash(\) e.g.:\F\r\o\m G:i .<br>This field will only be shown when date part of enddate is equal to start date and format not empty.</p>', 'simple_ical');
+        _e('<p><strong>Time format start time</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Time format start time. Default: G:i,<br>G or g = 24 or 12 hour format of an hour without leading zeros<br>i = Minutes with leading zeros<br>a or A = Lowercase or Uppercase Ante meridiem and Post meridiem<br>make empty if you don\'t want to show start time.<br>You can also use other text to embellish it<br>escape characters with special meaning with a slash(\) e.g.:\F\r\o\m G:i .<br>This field will only be shown when date part of enddate is equal to start date and format not empty.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Time format end time</strong></p>', 'simple_ical');
-        _e('<p>Time format separator and end time. Default:  - G:i,<br>G or g = 24 or 12 hour format of an hour without leading zeros<br>i = Minutes with leading zeros<br>a or A = Lowercase or Uppercase Ante meridiem and Post meridiem<br>make empty if you don\'t want to show end time.<br>You can also use other text to embellish it<br>escape characters with special meaning with a slash(\)e.g.: \t\o G:i .<br>This field will only be shown when date part of enddate is equal to start date and format not empty.</p>', 'simple_ical');
+        _e('<p><strong>Time format end time</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Time format separator and end time. Default:  - G:i,<br>G or g = 24 or 12 hour format of an hour without leading zeros<br>i = Minutes with leading zeros<br>a or A = Lowercase or Uppercase Ante meridiem and Post meridiem<br>make empty if you don\'t want to show end time.<br>You can also use other text to embellish it<br>escape characters with special meaning with a slash(\)e.g.: \t\o G:i .<br>This field will only be shown when date part of enddate is equal to start date and format not empty.</p>', 'simple-google-icalendar-widget');
 
         _e('<h3>Advanced settings</h3>' );
         
-        _e('<p><strong>Calendar cache expiration time in minutes</strong></p>', 'simple_ical');
-        _e('<p>Minimal time in minutes between reads from calendar source.</p>', 'simple_ical');
+        _e('<p><strong>Calendar cache expiration time in minutes</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Minimal time in minutes between reads from calendar source.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Excerpt length</strong></p>', 'simple_ical');
-        _e('<p>Max length of the description in characters.<br>If there is a space or end-of-line character within 10 characters of this end, break there.<br>Note, not all characters have the same width, so the number of lines is not completely fixed by this. So you need additional CSS for that.<br><b>Warning:</b> If you allow html in the description, necessary end tags may disappear here.<br> Default: empty, all characters will be displayed</p>', 'simple_ical');
+        _e('<p><strong>Excerpt length</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Max length of the description in characters.<br>If there is a space or end-of-line character within 10 characters of this end, break there.<br>Note, not all characters have the same width, so the number of lines is not completely fixed by this. So you need additional CSS for that.<br><b>Warning:</b> If you allow html in the description, necessary end tags may disappear here.<br> Default: empty, all characters will be displayed</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Tag for summary</strong></p>', 'simple_ical');
-        _e('<p>Tag for summary. Choose a tag from the list. Default: a (link)<br>When using bootstrap or other collapse css and java-script the description is collapsed and wil be opened bij clicking on the summary link.<br>Link is not included with the other tags.<br>If not using bootstrap h4, div or strong may be a better choice then a..</p>', 'simple_ical');
-        _e('<p>Only available in block.</p>', 'simple_ical');
+        _e('<p><strong>Tag for summary</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Tag for summary. Choose a tag from the list. Default: a (link)<br>When using bootstrap or other collapse css and java-script the description is collapsed and wil be opened bij clicking on the summary link.<br>Link is not included with the other tags.<br>If not using bootstrap h4, div or strong may be a better choice then a..</p>', 'simple-google-icalendar-widget');
+        _e('<p>Only available in block.</p>', 'simple-google-icalendar-widget');
         
         
-        _e('<p><strong>Suffix group class</strong></p>', 'simple_ical');
-        _e('<p>Suffix to add after css-class around the event (list-group),<br>start with space to keep the original class and add another class.</p>', 'simple_ical');
+        _e('<p><strong>Suffix group class</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Suffix to add after css-class around the event (list-group),<br>start with space to keep the original class and add another class.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Suffix event start class</strong></p>', 'simple_ical');
-        _e('<p>Suffix to add after the css-class around the event start line (list-group-item),<br>start with space to keep the original class and add another class.<br>E.g.:  py-0 with leading space; standard bootstrap 4 class to set padding top and bottom  to 0;  ml-1 to set margin left to 0.25 rem</p>', 'simple_ical');
+        _e('<p><strong>Suffix event start class</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Suffix to add after the css-class around the event start line (list-group-item),<br>start with space to keep the original class and add another class.<br>E.g.:  py-0 with leading space; standard bootstrap 4 class to set padding top and bottom  to 0;  ml-1 to set margin left to 0.25 rem</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Suffix event details classs</strong></p>', 'simple_ical');
-        _e('<p>Suffix to add after the css-class around the event details link (ical_details),<br>start with space to keep the original class and add another class.</p>', 'simple_ical');
+        _e('<p><strong>Suffix event details classs</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Suffix to add after the css-class around the event details link (ical_details),<br>start with space to keep the original class and add another class.</p>', 'simple-google-icalendar-widget');
 
-        _e('<p><strong>Checkbox Allow safe html in description and summary.</strong></p>', 'simple_ical');
-        _e('<p>Check checkbox to allow the use of some safe html in description and summary,<br>otherwise it will only be displayed as text.</p>', 'simple_ical');
+        _e('<p><strong>Checkbox Allow safe html in description and summary.</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Check checkbox to allow the use of some safe html in description and summary,<br>otherwise it will only be displayed as text.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Closing HTML after available events.</strong></p>', 'simple_ical');
-        _e('<p>Closing (safe) HTML after events list, when events are available.<br><br>This text with simple HTML will be displayed after the events list.<br>Use &amp;lt; or &amp;gt; if you want to output &lt; or &gt; otherwise they may be removed as unknown and therefore unsafe tags.<br>E.g. &lt;hr class=&quot;module-ft&quot;	&gt;.</p>', 'simple_ical');
+        _e('<p><strong>Closing HTML after available events.</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Closing (safe) HTML after events list, when events are available.<br><br>This text with simple HTML will be displayed after the events list.<br>Use &amp;lt; or &amp;gt; if you want to output &lt; or &gt; otherwise they may be removed as unknown and therefore unsafe tags.<br>E.g. &lt;hr class=&quot;module-ft&quot;	&gt;.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Closing HTML when no events.</strong></p>', 'simple_ical');
-        _e('<p>Closing (safe) HTML output when no events are available.<br>This text with simple HTML will be displayed instead of the events list.<br>Use &amp;lt; or &amp;gt; if you want to output &lt; or &gt; otherwise they may be removed as unknown and therefore unsafe tags.<br>E.g. &lt;p  class=&quot;warning&quot; &gt;&amp;lt; No events found. &amp;gt;&lt;\p&gt;&lt;hr class=&quot;module-ft&quot;&gt;.</p>', 'simple_ical');
+        _e('<p><strong>Closing HTML when no events.</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Closing (safe) HTML output when no events are available.<br>This text with simple HTML will be displayed instead of the events list.<br>Use &amp;lt; or &amp;gt; if you want to output &lt; or &gt; otherwise they may be removed as unknown and therefore unsafe tags.<br>E.g. &lt;p  class=&quot;warning&quot; &gt;&amp;lt; No events found. &amp;gt;&lt;\p&gt;&lt;hr class=&quot;module-ft&quot;&gt;.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>Button Reset ID</strong></p>', 'simple_ical');
-        _e('<p>Press button Reset ID to copy the blockid from the clientid in the editor after duplicating the block, to make blockid unique again.</p>', 'simple_ical');
-        _e('<p>In the legacy widget the uniqid() function is used to create a new blockid.</p>', 'simple_ical');
-        _e('<p>Since the transient cache id is derived from the block id, this also clears the data cache once.</p>', 'simple_ical');
+        _e('<p><strong>Button Reset ID</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>Press button Reset ID to copy the blockid from the clientid in the editor after duplicating the block, to make blockid unique again.</p>', 'simple-google-icalendar-widget');
+        _e('<p>In the legacy widget the uniqid() function is used to create a new blockid.</p>', 'simple-google-icalendar-widget');
+        _e('<p>Since the transient cache id is derived from the block id, this also clears the data cache once.</p>', 'simple-google-icalendar-widget');
         
-        _e('<p><strong>HTML anchor</strong></p>', 'simple_ical');
-        _e('<p>HTML anchor for this block.<br>Type one or two words — no spaces — to create a unique web address for this block, called an “anchor.” Then you can link directly to this section on your page.<br>You can als use this ID to make parts of your extra css specific for this block</p>', 'simple_ical');
-        _e('<p>Only available in block.</p>', 'simple_ical');
+        _e('<p><strong>HTML anchor</strong></p>', 'simple-google-icalendar-widget');
+        _e('<p>HTML anchor for this block.<br>Type one or two words — no spaces — to create a unique web address for this block, called an “anchor.” Then you can link directly to this section on your page.<br>You can als use this ID to make parts of your extra css specific for this block</p>', 'simple-google-icalendar-widget');
+        _e('<p>Only available in block.</p>', 'simple-google-icalendar-widget');
         
         echo('</div>');
         

--- a/js/simple-ical-block.js
+++ b/js/simple-ical-block.js
@@ -4,7 +4,7 @@
  * Move styles to stylesheets - both edit and front-end.
  * and use attributes and editable fields
  * attributes as Inspectorcontrols (settings)
- * v2.1.4
+ * v2.2.0
  * 20230625 added quotes to the options of the Layout SelectControl,
  *  add parseInt to all integers in transform, added conversion dateformat_lgend and _tsend and anchorid = blockid
  * 20230420 added parseInt on line 147(now 148) to keep layout in block-editor
@@ -15,6 +15,7 @@
  *   excerptlength initialised with '' so cannot be integer, all parseInt(value) followed bij || 0,1,or 2  because result must comply type validation of REST endpoint and '' or NaN don't. (rest_invalid_type)
  *   preponed 'b' to blockid, because html id must not start with number.
  *   wp.components.ServerSideRender deprecated replaced by serverSideRender and dependency wp-server-side-render; clear_cache_now false after 1 second, to prevent excessive calling of calendar
+ * 20240106 Added help to (some) settings.
  */
 ( function(blocks, i18n, element, blockEditor, components, serverSideRender ) {
 	var el = element.createElement;
@@ -119,14 +120,19 @@
                     TextControl,
                     {   label: __('Title:', 'simple_ical'),
                         value: props.attributes.title,
+                        help: __('Title of this instance of the widget', 'simple_ical'),
                         onChange: function( value ) { props.setAttributes( { title: value } );},
+ 
                     }
                 ),
                 el(
                     TextControl,
                     {   label: __('Calendar ID, or iCal URL:', 'simple_ical'),
                         value: props.attributes.calendar_id,
+                        help: __("The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID's. Optional you can add a html-class separated by a semicolon to some or all ID's to distinguish calendars in the lay-out.", 'simple_ical'),  
                         onChange: function( value ) { props.setAttributes( { calendar_id: value } );},
+
+
                     }
                 ),
                 el(
@@ -228,6 +234,7 @@
                     SelectControl,
                     {   label: __('Tag for summary:', 'simple_ical'),
                         value: props.attributes.tag_sum,
+                        help: __('If not using bootstrap h4, div or strong may be a better choice then a', 'simple_ical'),
                         onChange: function( value ) { props.setAttributes( { tag_sum: value } );},
 					    options:  [
 							        { value: 'a', label: __('a (link)', 'simple_ical') },
@@ -247,6 +254,7 @@
                     TextControl,
                     {   label: __('Suffix group class:', 'simple_ical'),
                         value: props.attributes.suffix_lg_class,
+                        help: __('Suffix to add after css-class around the event set, start with space to keep the original class and add another class (list-group).', 'simple_ical'),
                         onChange: function( value ) { props.setAttributes( { suffix_lg_class: value } );},
                     }
                 ),
@@ -254,6 +262,7 @@
                     TextControl,
                     {   label: __('Suffix event start class:', 'simple_ical'),
                         value: props.attributes.suffix_lgi_class,
+                        help: __('Suffix to add after the css-class around each event occurrence, start with space to keep the original class (list-group-item), and add another class.', 'simple_ical'),
                         onChange: function( value ) { props.setAttributes( { suffix_lgi_class: value } );},
                     }
                 ),
@@ -261,6 +270,7 @@
                     TextControl,
                     {   label: __('Suffix event details class:', 'simple_ical'),
                         value: props.attributes.suffix_lgia_class,
+                        help: __('Suffix to add after the css-class around the event summary and details, start with space to keep the original class (ical_summary and ical_details) and add another class.', 'simple_ical'),
                         onChange: function( value ) { props.setAttributes( { suffix_lgia_class: value } );},
                     }
                 ),
@@ -305,6 +315,7 @@
                     TextControl,
                     {   label: __('HTML anchor:', 'simple_ical'),
                         value: props.attributes.anchorId,
+                        help: __('HTML anchor for this block. Type one or two words no spaces to create a unique web address for this block, called an "anchor". Then you can link directly to this section on your page. You can als use this ID to make parts of your extra css refer specific to this block', 'simple_ical'),
                         onChange: function( value ) { props.setAttributes( { anchorId: value } );},
                     }
                 )

--- a/js/simple-ical-block.js
+++ b/js/simple-ical-block.js
@@ -16,6 +16,7 @@
  *   preponed 'b' to blockid, because html id must not start with number.
  *   wp.components.ServerSideRender deprecated replaced by serverSideRender and dependency wp-server-side-render; clear_cache_now false after 1 second, to prevent excessive calling of calendar
  * 20240106 Added help to (some) settings. Changed the text domain to simple-google-icalendar-widget to make translations work by following the WP standard
+ *   wrong part of blockname "simplegoogleicalenderwidget" cannot be changed because it is safed in the page and changing gives an error.
  */
 ( function(blocks, i18n, element, blockEditor, components, serverSideRender ) {
 	var el = element.createElement;

--- a/js/simple-ical-block.js
+++ b/js/simple-ical-block.js
@@ -15,7 +15,7 @@
  *   excerptlength initialised with '' so cannot be integer, all parseInt(value) followed bij || 0,1,or 2  because result must comply type validation of REST endpoint and '' or NaN don't. (rest_invalid_type)
  *   preponed 'b' to blockid, because html id must not start with number.
  *   wp.components.ServerSideRender deprecated replaced by serverSideRender and dependency wp-server-side-render; clear_cache_now false after 1 second, to prevent excessive calling of calendar
- * 20240106 Added help to (some) settings.
+ * 20240106 Added help to (some) settings. Changed the text domain to simple-google-icalendar-widget to make translations work by following the WP standard
  */
 ( function(blocks, i18n, element, blockEditor, components, serverSideRender ) {
 	var el = element.createElement;
@@ -118,18 +118,18 @@
    			    {className: 'components-panel__body is-opened'},
                 el(
                     TextControl,
-                    {   label: __('Title:', 'simple_ical'),
+                    {   label: __('Title:', 'simple-google-icalendar-widget'),
                         value: props.attributes.title,
-                        help: __('Title of this instance of the widget', 'simple_ical'),
+                        help: __('Title of this instance of the widget', 'simple-google-icalendar-widget'),
                         onChange: function( value ) { props.setAttributes( { title: value } );},
  
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Calendar ID, or iCal URL:', 'simple_ical'),
+                    {   label: __('Calendar ID, or iCal URL:', 'simple-google-icalendar-widget'),
                         value: props.attributes.calendar_id,
-                        help: __("The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID's. Optional you can add a html-class separated by a semicolon to some or all ID's to distinguish calendars in the lay-out.", 'simple_ical'),  
+                        help: __("The Google calendar ID, or the URL of te iCal file to display, or #example, or comma separated list of ID's. Optional you can add a html-class separated by a semicolon to some or all ID's to distinguish calendars in the lay-out.", 'simple-google-icalendar-widget'),  
                         onChange: function( value ) { props.setAttributes( { calendar_id: value } );},
 
 
@@ -137,68 +137,68 @@
                 ),
                 el(
                     TextControl,
-                    {   label: __('Number of events displayed:', 'simple_ical'),
+                    {   label: __('Number of events displayed:', 'simple-google-icalendar-widget'),
                         value: props.attributes.event_count,
                         onChange: function( value ) { props.setAttributes( { event_count: Math.max((parseInt(value) || 1),1) } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Number of days after today with events displayed:', 'simple_ical'),
+                    {   label: __('Number of days after today with events displayed:', 'simple-google-icalendar-widget'),
                         value: props.attributes.event_period,
                         onChange: function( value ) { props.setAttributes( { event_period: Math.max((parseInt(value) || 1),1) } );},
                     }
                 ),
                 el(
                     SelectControl,
-                    {   label: __('Lay-out:', 'simple_ical'),
+                    {   label: __('Lay-out:', 'simple-google-icalendar-widget'),
                         value: props.attributes.layout,
                         onChange: function( value ) { props.setAttributes( { layout: parseInt(value) } );},
 					    options:  [
-							        { value: 1, label: __('Startdate higher level', 'simple_ical') },
-							        { value: 2, label: __('Start with summary', 'simple_ical') },
-								    { value: 3, label: __('Old style', 'simple_ical') }
+							        { value: 1, label: __('Startdate higher level', 'simple-google-icalendar-widget') },
+							        { value: 2, label: __('Start with summary', 'simple-google-icalendar-widget') },
+								    { value: 3, label: __('Old style', 'simple-google-icalendar-widget') }
     							] 
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Date format first line:', 'simple_ical'),
+                    {   label: __('Date format first line:', 'simple-google-icalendar-widget'),
                         value: props.attributes.dateformat_lg,
                         onChange: function( value ) { props.setAttributes( { dateformat_lg: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Enddate format first line:', 'simple_ical'),
+                    {   label: __('Enddate format first line:', 'simple-google-icalendar-widget'),
                         value: props.attributes.dateformat_lgend,
                         onChange: function( value ) { props.setAttributes( { dateformat_lgend: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Time format time summary line:', 'simple_ical'),
+                    {   label: __('Time format time summary line:', 'simple-google-icalendar-widget'),
                         value: props.attributes.dateformat_tsum,
                         onChange: function( value ) { props.setAttributes( { dateformat_tsum: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Time format end time summary line:', 'simple_ical'),
+                    {   label: __('Time format end time summary line:', 'simple-google-icalendar-widget'),
                         value: props.attributes.dateformat_tsend,
                         onChange: function( value ) { props.setAttributes( { dateformat_tsend: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Time format start time:', 'simple_ical'),
+                    {   label: __('Time format start time:', 'simple-google-icalendar-widget'),
                         value: props.attributes.dateformat_tstart,
                         onChange: function( value ) { props.setAttributes( { dateformat_tstart: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Time format end time:', 'simple_ical'),
+                    {   label: __('Time format end time:', 'simple-google-icalendar-widget'),
                         value: props.attributes.dateformat_tend,
                         onChange: function( value ) { props.setAttributes( { dateformat_tend: value } );},
                     }
@@ -208,7 +208,7 @@
                     {  href: 'admin.php?page=simple_ical_info',
 					   target: '_blank',
                     },
-					__('Need help?', 'simple_ical')
+					__('Need help?', 'simple-google-icalendar-widget')
                 )
             )
             ),
@@ -216,14 +216,14 @@
 				{key: 'advancedsetting'},
                 el(
                     TextControl,
-                    {   label: __('Cache expiration time in minutes:', 'simple_ical'),
+                    {   label: __('Cache expiration time in minutes:', 'simple-google-icalendar-widget'),
                         value: props.attributes.cache_time,
                         onChange: function( value ) { props.setAttributes( { cache_time: Math.max((parseInt(value) || 1),2) } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Excerpt length, max length of description:', 'simple_ical'),
+                    {   label: __('Excerpt length, max length of description:', 'simple-google-icalendar-widget'),
                         value: props.attributes.excerptlength,
                         onChange: function( value ) {parsed =  parseInt(value);
                                                      if (isNaN(parsed)) {parsed = ''};
@@ -232,80 +232,80 @@
                 ),
                 el(
                     SelectControl,
-                    {   label: __('Tag for summary:', 'simple_ical'),
+                    {   label: __('Tag for summary:', 'simple-google-icalendar-widget'),
                         value: props.attributes.tag_sum,
-                        help: __('If not using bootstrap h4, div or strong may be a better choice then a', 'simple_ical'),
+                        help: __('If not using bootstrap h4, div or strong may be a better choice then a', 'simple-google-icalendar-widget'),
                         onChange: function( value ) { props.setAttributes( { tag_sum: value } );},
 					    options:  [
-							        { value: 'a', label: __('a (link)', 'simple_ical') },
-							        { value: 'b', label: __('b (attention, bold)', 'simple_ical') },
-								    { value: 'div', label: __('div', 'simple_ical') },
-								    { value: 'h4', label: __('h4 (sub header)', 'simple_ical') },
-								    { value: 'h5', label: __('h5 (sub header)', 'simple_ical') },
-								    { value: 'h6', label: __('h6 (sub header)', 'simple_ical') },
-							        { value: 'i', label: __('i (idiomatic, italic)', 'simple_ical') },
-								    { value: 'span', label: __('span', 'simple_ical') },
-								    { value: 'strong', label: __('strong', 'simple_ical') },
-							        { value: 'u', label: __('u (unarticulated, underline )', 'simple_ical') }
+							        { value: 'a', label: __('a (link)', 'simple-google-icalendar-widget') },
+							        { value: 'b', label: __('b (attention, bold)', 'simple-google-icalendar-widget') },
+								    { value: 'div', label: __('div', 'simple-google-icalendar-widget') },
+								    { value: 'h4', label: __('h4 (sub header)', 'simple-google-icalendar-widget') },
+								    { value: 'h5', label: __('h5 (sub header)', 'simple-google-icalendar-widget') },
+								    { value: 'h6', label: __('h6 (sub header)', 'simple-google-icalendar-widget') },
+							        { value: 'i', label: __('i (idiomatic, italic)', 'simple-google-icalendar-widget') },
+								    { value: 'span', label: __('span', 'simple-google-icalendar-widget') },
+								    { value: 'strong', label: __('strong', 'simple-google-icalendar-widget') },
+							        { value: 'u', label: __('u (unarticulated, underline )', 'simple-google-icalendar-widget') }
     							] 
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Suffix group class:', 'simple_ical'),
+                    {   label: __('Suffix group class:', 'simple-google-icalendar-widget'),
                         value: props.attributes.suffix_lg_class,
-                        help: __('Suffix to add after css-class around the event set, start with space to keep the original class and add another class (list-group).', 'simple_ical'),
+                        help: __('Suffix to add after css-class around the event set, start with space to keep the original class and add another class (list-group).', 'simple-google-icalendar-widget'),
                         onChange: function( value ) { props.setAttributes( { suffix_lg_class: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Suffix event start class:', 'simple_ical'),
+                    {   label: __('Suffix event start class:', 'simple-google-icalendar-widget'),
                         value: props.attributes.suffix_lgi_class,
-                        help: __('Suffix to add after the css-class around each event occurrence, start with space to keep the original class (list-group-item), and add another class.', 'simple_ical'),
+                        help: __('Suffix to add after the css-class around each event occurrence, start with space to keep the original class (list-group-item), and add another class.', 'simple-google-icalendar-widget'),
                         onChange: function( value ) { props.setAttributes( { suffix_lgi_class: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Suffix event details class:', 'simple_ical'),
+                    {   label: __('Suffix event details class:', 'simple-google-icalendar-widget'),
                         value: props.attributes.suffix_lgia_class,
-                        help: __('Suffix to add after the css-class around the event summary and details, start with space to keep the original class (ical_summary and ical_details) and add another class.', 'simple_ical'),
+                        help: __('Suffix to add after the css-class around the event summary and details, start with space to keep the original class (ical_summary and ical_details) and add another class.', 'simple-google-icalendar-widget'),
                         onChange: function( value ) { props.setAttributes( { suffix_lgia_class: value } );},
                     }
                 ),
                 el(
                     ToggleControl,
-                    {   label: __('Allow safe html in description and summary.', 'simple_ical'),
+                    {   label: __('Allow safe html in description and summary.', 'simple-google-icalendar-widget'),
                         checked: props.attributes.allowhtml,
                         onChange: function( value ) { props.setAttributes( { allowhtml: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Closing HTML after available events:', 'simple_ical'),
+                    {   label: __('Closing HTML after available events:', 'simple-google-icalendar-widget'),
                         value: props.attributes.after_events,
                         onChange: function( value ) { props.setAttributes( { after_events: value } );},
                     }
                 ),
                 el(
                     TextControl,
-                    {   label: __('Closing HTML when no events:', 'simple_ical'),
+                    {   label: __('Closing HTML when no events:', 'simple-google-icalendar-widget'),
                         value: props.attributes.no_events,
                         onChange: function( value ) { props.setAttributes( { no_events: value } );},
                     }
                 ),
                 el(
                     ToggleControl,
-                    {   label: __('Clear cache.', 'simple_ical'),
+                    {   label: __('Clear cache.', 'simple-google-icalendar-widget'),
                         checked: props.attributes.clear_cache_now,
                         onChange: function( value ) { props.setAttributes( { clear_cache_now: value } );},
                     }
                 ),
                 el(
                     Button,
-                    {   text: __('Reset ID.', 'simple_ical'),
-                        label: __('Reset ID, only necessary after duplicating block', 'simple_ical'),
+                    {   text: __('Reset ID.', 'simple-google-icalendar-widget'),
+                        label: __('Reset ID, only necessary after duplicating block', 'simple-google-icalendar-widget'),
                         showTooltip: true,
                         variant: 'secondary',
                         onClick: function( ) { props.setAttributes( { blockid: 'b' + props.clientId } );},
@@ -313,9 +313,9 @@
                 ),
                 el(
                     TextControl,
-                    {   label: __('HTML anchor:', 'simple_ical'),
+                    {   label: __('HTML anchor:', 'simple-google-icalendar-widget'),
                         value: props.attributes.anchorId,
-                        help: __('HTML anchor for this block. Type one or two words no spaces to create a unique web address for this block, called an "anchor". Then you can link directly to this section on your page. You can als use this ID to make parts of your extra css refer specific to this block', 'simple_ical'),
+                        help: __('HTML anchor for this block. Type one or two words no spaces to create a unique web address for this block, called an "anchor". Then you can link directly to this section on your page. You can als use this ID to make parts of your extra css refer specific for this block', 'simple-google-icalendar-widget'),
                         onChange: function( value ) { props.setAttributes( { anchorId: value } );},
                     }
                 )

--- a/simple-google-icalendar-widget.php
+++ b/simple-google-icalendar-widget.php
@@ -4,9 +4,9 @@
  Description: Widget that displays events from a public google calendar or iCal file
  Plugin URI: https://github.com/bramwaas/wordpress-plugin-wsa-simple-google-calendar-widget
  Author: Bram Waasdorp
- Version: 2.1.5
+ Version: 2.2.0
  License: GPL3
- Tested up to: 6.3
+ Tested up to: 6.4
  Requires at least: 5.3
  Requires PHP:  5.3.0 tested with 7.4
  Text Domain:  simple-google-icalendar-widget

--- a/simple-google-icalendar-widget.php
+++ b/simple-google-icalendar-widget.php
@@ -6,10 +6,10 @@
  Author: Bram Waasdorp
  Version: 2.1.5
  License: GPL3
- Tested up to: 6.4
+ Tested up to: 6.3
  Requires at least: 5.3
  Requires PHP:  5.3.0 tested with 7.4
- Text Domain:  simple_ical
+ Text Domain:  simple-google-icalendar-widget
  Domain Path:  /languages
  *   bw 20201122 v1.2.0 find solution for DTSTART and DTEND without time by explicit using isDate and only displaying times when isDate === false.;
  *               found that date_i18n($format, $timestamp) formats according to the locale, but not the timezone but the newer function wp_date() does,
@@ -24,24 +24,24 @@
  *   bw 20220404 V1.5.0 in response to a support topic on github of fhennies added parameter allowhtml (htmlspecialchars) to allow Html
  *               in Description, Summary and Location added wp_kses('post') to output to keep preventing XSS
  *   bw 20220407 Extra options for parser in array poptions and added temporary new option notprocessdst to don't process differences in DST between start of series events and the current event.
- *      20220410 V1.5.1 As notprocessdst is always better within one timezone removed the correction and this option. 
- *               If this causes other problems when using more timezones then find specific solution. 
- *   bw 20220421 V1.6.0 First steps to convert widget to block 
- *      20220430 Block in own class  SimpleicalBlock called when function_exists( 'register_block_type') else old widget (later maybe always also old widget)  
+ *      20220410 V1.5.1 As notprocessdst is always better within one timezone removed the correction and this option.
+ *               If this causes other problems when using more timezones then find specific solution.
+ *   bw 20220421 V1.6.0 First steps to convert widget to block
+ *      20220430 Block in own class  SimpleicalBlock called when function_exists( 'register_block_type') else old widget (later maybe always also old widget)
  *   bw 20220503 Replaced ( function_exists( 'register_block_type' ) ) by ( is_wp_version_compatible( '5.9' ) ) because we use the newest version of blocks and removed else for the old widget, so that
- *              the legacy block with the old widget still keeps working                   
+ *              the legacy block with the old widget still keeps working
  *   bw 20230403 v2.1.1 replaced almost all of the widget (display) function by a call to SimpleicalBlock::display_block($instance); to make the html roughly the same as that of the block.
- *               added layout setting in the settings form. removed strip-tags from date-time fields in settings form 
- *   bw 20230409 v2.1.2 small adjustments befor_widget id (probably without effect) 
+ *               added layout setting in the settings form. removed strip-tags from date-time fields in settings form
+ *   bw 20230409 v2.1.2 small adjustments befor_widget id (probably without effect)
  *   bw 20230418 v2.1.3 added optional placeholder HTML output when no upcoming events are avalable. Also added optional output after the events list (when upcoming events are available).
  *   bw 20230623 v2.1.4 solved a number of typos in dateformat_... in update function to save all options.
  *   bw 20230823 v2.1.5 added defaults from SimpleicalBlock block_attributes for all used keys in instance to prevent Undefined array key warnings/errors.
- *   bw 20231104 tested with 6.4-RC3.
+ *   bw 20240106 v2.2.0 Changed the text domain to simple-google-icalendar-widget to make translations work by following the WP standard
  */
 /*
  Simple Google Calendar Outlook Events Widget
- Copyright (C) Bram Waasdorp 2017 - 2023
- 2023-08-23
+ Copyright (C) Bram Waasdorp 2017 - 2024
+ 2024-01-06
  Forked from Simple Google Calendar Widget v 0.7 by Nico Boehr
  
  This program is free software: you can redistribute it and/or modify
@@ -57,279 +57,279 @@
  You should have received a copy of the GNU General Public License
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-use WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\IcsParser;
-use WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalBlock;
-use WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalWidgetAdmin;
+use WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\IcsParser;
+use WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalBlock;
+use WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalWidgetAdmin;
 
-if (!class_exists('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\IcsParser')) {
+if (!class_exists('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\IcsParser')) {
     require_once( 'includes/IcsParser.php' );
-    class_alias('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\IcsParser', 'IcsParser');
+    class_alias('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\IcsParser', 'IcsParser');
 }
 
-if (!class_exists('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalBlock')) {
+if (!class_exists('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalBlock')) {
     require_once( 'includes/SimpleicalBlock.php' );
-    class_alias('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalBlock', 'SimpleicalBlock');
+    class_alias('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalBlock', 'SimpleicalBlock');
 }
-if (!class_exists('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalWidgetAdmin')) {
+if (!class_exists('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalWidgetAdmin')) {
     require_once('includes/SimpleicalWidgetAdmin.php');
-    class_alias('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalWidgetAdmin', 'SimpleicalWidgetAdmin');
+    class_alias('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalWidgetAdmin', 'SimpleicalWidgetAdmin');
 }
 if ( is_wp_version_compatible( '5.9' ) )   { // block widget
     // Static class method call with name of the class
-    add_action( 'init', array ('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalenderWidget\SimpleicalBlock', 'init_block') );
-
+    add_action( 'init', array ('WaasdorpSoekhan\WP\Plugin\SimpleGoogleIcalendarWidget\SimpleicalBlock', 'init_block') );
+    
 } // end function_exists( 'register_block_type' )
 
 { //old widget
-	
-if ( !class_exists( 'Simple_iCal_Widget' ) ) {
-class Simple_iCal_Widget extends WP_Widget
-{
-/* 
-* contruct the old widget
-*
-*/
-    public function __construct()
-    {
-        // load our textdomain
-        load_plugin_textdomain('simple_ical', false, basename( dirname( __FILE__ ) ) . '/languages' );
-        
-        parent::__construct('simple_ical_widget', // Base ID
-            'Simple Google iCalendar Widget', // Name
-            array( // Args
-                'classname' => 'Simple_iCal_Widget',
-                'description' => __('Displays events from a public Google Calendar or other iCal source', 'simple_ical'),
-                'show_instance_in_rest' => true, // allow migrating to block
-            )
-            );
-    }
-  
-    /**
-     * Front-end display of widget.
-     *
-     * @see WP_Widget::widget()
-     *
-     * @param array $args     Widget arguments.
-     * @param array $instance Saved values from database.
-     */
-    public function widget($args, $instance)
-    {
-
-        $instance = wp_parse_args((array) $instance,
-            (array ('title' => __('Events', 'simple_ical')) + SimpleicalBlock::$default_block_attributes));
-       
-
-// title widget
-        $title = apply_filters('widget_title', $instance['title']);
-        echo sprintf($args['before_widget'], $instance['blockid'], 'Simple_iCal_Widget ') ;
-        if(isset($instance['title'])) {
-            echo $args['before_title'], $title, $args['after_title'];
-        }
-// lay-out block:
-        $instance['wptype'] = 'widget';
-        $instance['clear_cache_now'] = false;
-        
-        
-        
-        SimpleicalBlock::display_block($instance);
-        
-// end lay-out block
-// after widget
-        echo $args['after_widget'];
-        
-        
     
-    }
-    /**
-     * Sanitize widget form values as they are saved.
-     *
-     * @see WP_Widget::update()
-     *
-     * @param array $new_instance Values just sent to be saved.
-     * @param array $old_instance Previously saved values from database.
-     *
-     * @return array Updated safe values to be saved.
-     */
-    public function update($new_instance, $old_instance)
-    {
-        $instance = $old_instance;
-        $instance['title'] = strip_tags($new_instance['title']);
-        
-        $instance['calendar_id'] = htmlspecialchars($new_instance['calendar_id']);
-        
-        if(is_numeric($new_instance['cache_time']) && $new_instance['cache_time'] > 1) {
-            $instance['cache_time'] = $new_instance['cache_time'];
-        } else {
-            $instance['cache_time'] = 60;
-        }
-        
-        if(is_numeric($new_instance['event_period']) && $new_instance['event_period'] > 1) {
-            $instance['event_period'] = $new_instance['event_period'];
-        } else {
-            $instance['event_period'] = 366;
-        }
-        
-        if(is_numeric($new_instance['layout']) && $new_instance['layout'] > 0) {
-            $instance['layout'] = $new_instance['layout'];
-        } else {
-            $instance['layout'] = 3;
-        }
-        
-        $instance['event_count'] = $new_instance['event_count'];
-        if(is_numeric($new_instance['event_count']) && $new_instance['event_count'] > 0) {
-            $instance['event_count'] = $new_instance['event_count'];
-        } else {
-            $instance['event_count'] = 5;
-        }
-        // using strip_tags because it can start with space or contain more classe seperated by spaces
-        $instance['dateformat_lg'] = ($new_instance['dateformat_lg']);
-        $instance['dateformat_lgend'] = ($new_instance['dateformat_lgend']);
-        $instance['dateformat_tsum'] = ($new_instance['dateformat_tsum']);
-        $instance['dateformat_tsend'] = ($new_instance['dateformat_tsend']);
-        $instance['dateformat_tstart'] = ($new_instance['dateformat_tstart']);
-        $instance['dateformat_tend'] = ($new_instance['dateformat_tend']);
-        if(is_numeric($new_instance['excerptlength']) && $new_instance['excerptlength'] >= 0) {
-            $instance['excerptlength'] = intval($new_instance['excerptlength']);
-        } else {
-            $instance['excerptlength'] = '';
-        }
-        $instance['tag_sum'] = strip_tags($new_instance['tag_sum']);
-        $instance['suffix_lg_class'] = strip_tags($new_instance['suffix_lg_class']);
-        $instance['suffix_lgi_class'] = strip_tags($new_instance['suffix_lgi_class']);
-        $instance['suffix_lgia_class'] = strip_tags($new_instance['suffix_lgia_class']);
-        $instance['after_events'] = ($new_instance['after_events']);
-        $instance['no_events'] = ($new_instance['no_events']);
-        $instance['allowhtml'] = !empty($new_instance['allowhtml']);
-        $instance['blockid'] = strip_tags($new_instance['blockid']);
-        
-        return $instance;
-    }
-    /**
-     * Back-end widget form.
-     *
-     * @see WP_Widget::form()
-     *
-     * @param array $instance Previously saved values from database.
-     */
-    public function form($instance)
-    {
-        
-        $default = wp_parse_args((array) array(
-            'wptype' => 'widget',
-            'blockid' => 'W' . uniqid(),
-        ),
-            (array ('title' => __('Events', 'simple_ical')) + SimpleicalBlock::$default_block_attributes));
-        
-        $instance = wp_parse_args((array) $instance, $default);
-        $nwblockid = 'w' . uniqid();
-        
-        ?>
+    if ( !class_exists( 'Simple_iCal_Widget' ) ) {
+        class Simple_iCal_Widget extends WP_Widget
+        {
+            /*
+             * contruct the old widget
+             *
+             */
+            public function __construct()
+            {
+                // load our textdomain
+                load_plugin_textdomain('simple-google-icalendar-widget', false, basename( dirname( __FILE__ ) ) . '/languages' );
+                
+                parent::__construct('simple_ical_widget', // Base ID
+                    'Simple Google iCalendar Widget', // Name
+                    array( // Args
+                        'classname' => 'Simple_iCal_Widget',
+                        'description' => __('Displays events from a public Google Calendar or other iCal source', 'simple-google-icalendar-widget'),
+                        'show_instance_in_rest' => true, // allow migrating to block
+                    )
+                    );
+            }
+            
+            /**
+             * Front-end display of widget.
+             *
+             * @see WP_Widget::widget()
+             *
+             * @param array $args     Widget arguments.
+             * @param array $instance Saved values from database.
+             */
+            public function widget($args, $instance)
+            {
+                
+                $instance = wp_parse_args((array) $instance,
+                    (array ('title' => __('Events', 'simple-google-icalendar-widget')) + SimpleicalBlock::$default_block_attributes));
+                
+                
+                // title widget
+                $title = apply_filters('widget_title', $instance['title']);
+                echo sprintf($args['before_widget'], $instance['blockid'], 'Simple_iCal_Widget ') ;
+                if(isset($instance['title'])) {
+                    echo $args['before_title'], $title, $args['after_title'];
+                }
+                // lay-out block:
+                $instance['wptype'] = 'widget';
+                $instance['clear_cache_now'] = false;
+                
+                
+                
+                SimpleicalBlock::display_block($instance);
+                
+                // end lay-out block
+                // after widget
+                echo $args['after_widget'];
+                
+                
+                
+            }
+            /**
+             * Sanitize widget form values as they are saved.
+             *
+             * @see WP_Widget::update()
+             *
+             * @param array $new_instance Values just sent to be saved.
+             * @param array $old_instance Previously saved values from database.
+             *
+             * @return array Updated safe values to be saved.
+             */
+            public function update($new_instance, $old_instance)
+            {
+                $instance = $old_instance;
+                $instance['title'] = strip_tags($new_instance['title']);
+                
+                $instance['calendar_id'] = htmlspecialchars($new_instance['calendar_id']);
+                
+                if(is_numeric($new_instance['cache_time']) && $new_instance['cache_time'] > 1) {
+                    $instance['cache_time'] = $new_instance['cache_time'];
+                } else {
+                    $instance['cache_time'] = 60;
+                }
+                
+                if(is_numeric($new_instance['event_period']) && $new_instance['event_period'] > 1) {
+                    $instance['event_period'] = $new_instance['event_period'];
+                } else {
+                    $instance['event_period'] = 366;
+                }
+                
+                if(is_numeric($new_instance['layout']) && $new_instance['layout'] > 0) {
+                    $instance['layout'] = $new_instance['layout'];
+                } else {
+                    $instance['layout'] = 3;
+                }
+                
+                $instance['event_count'] = $new_instance['event_count'];
+                if(is_numeric($new_instance['event_count']) && $new_instance['event_count'] > 0) {
+                    $instance['event_count'] = $new_instance['event_count'];
+                } else {
+                    $instance['event_count'] = 5;
+                }
+                // using strip_tags because it can start with space or contain more classe seperated by spaces
+                $instance['dateformat_lg'] = ($new_instance['dateformat_lg']);
+                $instance['dateformat_lgend'] = ($new_instance['dateformat_lgend']);
+                $instance['dateformat_tsum'] = ($new_instance['dateformat_tsum']);
+                $instance['dateformat_tsend'] = ($new_instance['dateformat_tsend']);
+                $instance['dateformat_tstart'] = ($new_instance['dateformat_tstart']);
+                $instance['dateformat_tend'] = ($new_instance['dateformat_tend']);
+                if(is_numeric($new_instance['excerptlength']) && $new_instance['excerptlength'] >= 0) {
+                    $instance['excerptlength'] = intval($new_instance['excerptlength']);
+                } else {
+                    $instance['excerptlength'] = '';
+                }
+                $instance['tag_sum'] = strip_tags($new_instance['tag_sum']);
+                $instance['suffix_lg_class'] = strip_tags($new_instance['suffix_lg_class']);
+                $instance['suffix_lgi_class'] = strip_tags($new_instance['suffix_lgi_class']);
+                $instance['suffix_lgia_class'] = strip_tags($new_instance['suffix_lgia_class']);
+                $instance['after_events'] = ($new_instance['after_events']);
+                $instance['no_events'] = ($new_instance['no_events']);
+                $instance['allowhtml'] = !empty($new_instance['allowhtml']);
+                $instance['blockid'] = strip_tags($new_instance['blockid']);
+                
+                return $instance;
+            }
+            /**
+             * Back-end widget form.
+             *
+             * @see WP_Widget::form()
+             *
+             * @param array $instance Previously saved values from database.
+             */
+            public function form($instance)
+            {
+                
+                $default = wp_parse_args((array) array(
+                    'wptype' => 'widget',
+                    'blockid' => 'W' . uniqid(),
+                ),
+                    (array ('title' => __('Events', 'simple-google-icalendar-widget')) + SimpleicalBlock::$default_block_attributes));
+                
+                $instance = wp_parse_args((array) $instance, $default);
+                $nwblockid = 'w' . uniqid();
+                
+                ?>
         <p>
-          <label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('title'); ?>"><?php _e('Title:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('title'); ?>" name="<?php echo $this->get_field_name('title'); ?>" type="text" value="<?php echo esc_attr($instance['title']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('calendar_id'); ?>"><?php _e('Calendar ID, or iCal URL:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('calendar_id'); ?>"><?php _e('Calendar ID, or iCal URL:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('calendar_id'); ?>" name="<?php echo $this->get_field_name('calendar_id'); ?>" type="text" value="<?php echo esc_attr($instance['calendar_id']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('event_count'); ?>"><?php _e('Number of events displayed:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('event_count'); ?>"><?php _e('Number of events displayed:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('event_count'); ?>" name="<?php echo $this->get_field_name('event_count'); ?>" type="text" value="<?php echo esc_attr($instance['event_count']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('event_period'); ?>"><?php _e('Number of days after today with events displayed:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('event_period'); ?>"><?php _e('Number of days after today with events displayed:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('event_period'); ?>" name="<?php echo $this->get_field_name('event_period'); ?>" type="text" value="<?php echo esc_attr($instance['event_period']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('layout'); ?>"><?php _e('Lay-out:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('layout'); ?>"><?php _e('Lay-out:', 'simple-google-icalendar-widget'); ?></label> 
           <select class="widefat" id="<?php echo $this->get_field_id('layout'); ?>" name="<?php echo $this->get_field_name('layout'); ?>" >
-            <option value="1"<?php echo (1==esc_attr($instance['layout']))?'selected':''; ?>><?php _e('Startdate higher level', 'simple_ical'); ?></option>
-  			<option value="2"<?php echo (2==esc_attr($instance['layout']))?'selected':''; ?>><?php _e('Start with summary', 'simple_ical'); ?></option>
-  			<option value="3"<?php echo (3==esc_attr($instance['layout']))?'selected':''; ?>><?php _e('Old style', 'simple_ical'); ?></option>
+            <option value="1"<?php echo (1==esc_attr($instance['layout']))?'selected':''; ?>><?php _e('Startdate higher level', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="2"<?php echo (2==esc_attr($instance['layout']))?'selected':''; ?>><?php _e('Start with summary', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="3"<?php echo (3==esc_attr($instance['layout']))?'selected':''; ?>><?php _e('Old style', 'simple-google-icalendar-widget'); ?></option>
   		 </select>	
         </p>
          <p>
-          <label for="<?php echo $this->get_field_id('dateformat_lg'); ?>"><?php _e('Date format first line:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('dateformat_lg'); ?>"><?php _e('Date format first line:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('dateformat_lg'); ?>" name="<?php echo $this->get_field_name('dateformat_lg'); ?>" type="text" value="<?php echo esc_attr($instance['dateformat_lg']); ?>" />
         </p>
          <p>
-          <label for="<?php echo $this->get_field_id('dateformat_lgend'); ?>"><?php _e('Enddate format first line:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('dateformat_lgend'); ?>"><?php _e('Enddate format first line:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('dateformat_lgend'); ?>" name="<?php echo $this->get_field_name('dateformat_lgend'); ?>" type="text" value="<?php echo esc_attr($instance['dateformat_lgend']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('dateformat_tsum'); ?>"><?php _e('Time format time summary line:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('dateformat_tsum'); ?>"><?php _e('Time format time summary line:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('dateformat_tsum'); ?>" name="<?php echo $this->get_field_name('dateformat_tsum'); ?>" type="text" value="<?php echo esc_attr($instance['dateformat_tsum']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('dateformat_tsend'); ?>"><?php _e('Time format end time summary line:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('dateformat_tsend'); ?>"><?php _e('Time format end time summary line:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('dateformat_tsend'); ?>" name="<?php echo $this->get_field_name('dateformat_tsend'); ?>" type="text" value="<?php echo esc_attr($instance['dateformat_tsend']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('dateformat_tstart'); ?>"><?php _e('Time format start time:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('dateformat_tstart'); ?>"><?php _e('Time format start time:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('dateformat_tstart'); ?>" name="<?php echo $this->get_field_name('dateformat_tstart'); ?>" type="text" value="<?php echo esc_attr($instance['dateformat_tstart']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('dateformat_tend'); ?>"><?php _e('Time format end time:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('dateformat_tend'); ?>"><?php _e('Time format end time:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('dateformat_tend'); ?>" name="<?php echo $this->get_field_name('dateformat_tend'); ?>" type="text" value="<?php echo esc_attr($instance['dateformat_tend']); ?>" />
         </p>
         <h4>Advanced</h4>
         <p>
-          <label for="<?php echo $this->get_field_id('cache_time'); ?>"><?php _e('Cache expiration time in minutes:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('cache_time'); ?>"><?php _e('Cache expiration time in minutes:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('cache_time'); ?>" name="<?php echo $this->get_field_name('cache_time'); ?>" type="text" value="<?php echo esc_attr($instance['cache_time']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('excerptlength'); ?>"><?php _e('Excerpt length, max length of description:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('excerptlength'); ?>"><?php _e('Excerpt length, max length of description:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('excerptlength'); ?>" name="<?php echo $this->get_field_name('excerptlength'); ?>" type="text" value="<?php echo esc_attr($instance['excerptlength']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('tag_sum'); ?>"><?php _e('Tag for summary:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('tag_sum'); ?>"><?php _e('Tag for summary:', 'simple-google-icalendar-widget'); ?></label> 
           <select class="widefat" id="<?php echo $this->get_field_id('tag_sum'); ?>" name="<?php echo $this->get_field_name('tag_sum'); ?>" >
-            <option value="a"<?php echo ('a'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('a (link)', 'simple_ical'); ?></option>
-  			<option value="b"<?php echo ('b'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('b (attention, bold)', 'simple_ical'); ?></option>
-  			<option value="div"<?php echo ('div'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('div', 'simple_ical'); ?></option>
-  			<option value="h4"<?php echo ('h4'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('h4 (sub header)', 'simple_ical'); ?></option>
-  			<option value="h5"<?php echo ('h5'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('h5 (sub header)', 'simple_ical'); ?></option>
-  			<option value="h6"<?php echo ('h6'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('h6 (sub header)', 'simple_ical'); ?></option>
-  			<option value="i"<?php echo ('i'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('i (idiomatic, italic)', 'simple_ical'); ?></option>
-  			<option value="span"<?php echo ('span'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('span', 'simple_ical'); ?></option>
-  			<option value="strong"<?php echo ('strong'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('strong', 'simple_ical'); ?></option>
-  			<option value="u"<?php echo ('u'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('u (unarticulated, underline )', 'simple_ical'); ?></option>
+            <option value="a"<?php echo ('a'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('a (link)', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="b"<?php echo ('b'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('b (attention, bold)', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="div"<?php echo ('div'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('div', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="h4"<?php echo ('h4'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('h4 (sub header)', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="h5"<?php echo ('h5'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('h5 (sub header)', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="h6"<?php echo ('h6'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('h6 (sub header)', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="i"<?php echo ('i'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('i (idiomatic, italic)', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="span"<?php echo ('span'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('span', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="strong"<?php echo ('strong'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('strong', 'simple-google-icalendar-widget'); ?></option>
+  			<option value="u"<?php echo ('u'==esc_attr($instance['tag_sum']))?'selected':''; ?>><?php _e('u (unarticulated, underline )', 'simple-google-icalendar-widget'); ?></option>
   		 </select>	
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('suffix_lg_class'); ?>"><?php _e('Suffix group class:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('suffix_lg_class'); ?>"><?php _e('Suffix group class:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('suffix_lg_class'); ?>" name="<?php echo $this->get_field_name('suffix_lg_class'); ?>" type="text" value="<?php echo esc_attr($instance['suffix_lg_class']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('suffix_lgi_class'); ?>"><?php _e('Suffix event start class:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('suffix_lgi_class'); ?>"><?php _e('Suffix event start class:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('suffix_lgi_class'); ?>" name="<?php echo $this->get_field_name('suffix_lgi_class'); ?>" type="text" value="<?php echo esc_attr($instance['suffix_lgi_class']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('suffix_lgia_class'); ?>"><?php _e('Suffix event details class:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('suffix_lgia_class'); ?>"><?php _e('Suffix event details class:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('suffix_lgia_class'); ?>" name="<?php echo $this->get_field_name('suffix_lgia_class'); ?>" type="text" value="<?php echo esc_attr($instance['suffix_lgia_class']); ?>" />
         </p>
         <p>
           <input class="checkbox" id="<?php echo $this->get_field_id('allowhtml'); ?>" name="<?php echo $this->get_field_name('allowhtml'); ?>" type="checkbox" value="1" <?php checked( '1', $instance['allowhtml'] ); ?> />
-          <label for="<?php echo $this->get_field_id('allowhtml'); ?>"><?php _e('Allow safe html in description and summary.', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('allowhtml'); ?>"><?php _e('Allow safe html in description and summary.', 'simple-google-icalendar-widget'); ?></label> 
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('after_events'); ?>"><?php _e('Closing HTML after available events:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('after_events'); ?>"><?php _e('Closing HTML after available events:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('after_events'); ?>" name="<?php echo $this->get_field_name('after_events'); ?>" type="text" value="<?php echo esc_attr($instance['after_events']); ?>" />
         </p>
         <p>
-          <label for="<?php echo $this->get_field_id('no_events'); ?>"><?php _e('Closing HTML when no events:', 'simple_ical'); ?></label> 
+          <label for="<?php echo $this->get_field_id('no_events'); ?>"><?php _e('Closing HTML when no events:', 'simple-google-icalendar-widget'); ?></label> 
           <input class="widefat" id="<?php echo $this->get_field_id('no_events'); ?>" name="<?php echo $this->get_field_name('no_events'); ?>" type="text" value="<?php echo esc_attr($instance['no_events']); ?>" />
         </p>
          <p>
-          <button class="button" id="<?php echo $this->get_field_id('reset_id'); ?>" name="<?php echo $this->get_field_name('reset_id'); ?>" onclick="document.getElementById('<?php echo $this->get_field_id('blockid'); ?>').value = '<?php echo $nwblockid; ?>'" type="button" ><?php _e('Reset ID.', 'simple_ical')  ?></button>
-          <label for="<?php echo $this->get_field_id('reset_id'); ?>"><?php _e('Reset ID, only necessary to clear cache or after duplicating block.', 'simple_ical'); ?></label> 
+          <button class="button" id="<?php echo $this->get_field_id('reset_id'); ?>" name="<?php echo $this->get_field_name('reset_id'); ?>" onclick="document.getElementById('<?php echo $this->get_field_id('blockid'); ?>').value = '<?php echo $nwblockid; ?>'" type="button" ><?php _e('Reset ID.', 'simple-google-icalendar-widget')  ?></button>
+          <label for="<?php echo $this->get_field_id('reset_id'); ?>"><?php _e('Reset ID, only necessary to clear cache or after duplicating block.', 'simple-google-icalendar-widget'); ?></label> 
         </p>
         <p>
           <input class="widefat" id="<?php echo $this->get_field_id('blockid'); ?>" name="<?php echo $this->get_field_name('blockid'); ?>" type="hidden" value="<?php echo esc_attr($instance['blockid']); ?>" />
         </p>
         <p>
             <?php echo '<a href="' . admin_url('admin.php?page=simple_ical_info') . '" target="_blank">' ; 
-                _e('Need help?', 'simple_ical'); 
+                _e('Need help?', 'simple-google-icalendar-widget'); 
                 echo '</a>';
                 ?>
         </p>

--- a/simple-google-icalendar-widget.php
+++ b/simple-google-icalendar-widget.php
@@ -6,7 +6,7 @@
  Author: Bram Waasdorp
  Version: 2.1.5
  License: GPL3
- Tested up to: 6.3
+ Tested up to: 6.4
  Requires at least: 5.3
  Requires PHP:  5.3.0 tested with 7.4
  Text Domain:  simple_ical
@@ -36,6 +36,7 @@
  *   bw 20230418 v2.1.3 added optional placeholder HTML output when no upcoming events are avalable. Also added optional output after the events list (when upcoming events are available).
  *   bw 20230623 v2.1.4 solved a number of typos in dateformat_... in update function to save all options.
  *   bw 20230823 v2.1.5 added defaults from SimpleicalBlock block_attributes for all used keys in instance to prevent Undefined array key warnings/errors.
+ *   bw 20231104 tested with 6.4-RC3.
  */
 /*
  Simple Google Calendar Outlook Events Widget


### PR DESCRIPTION
after an issue of gonzob (@gonzob) in WP support forum: 'Bug with repeating events ' improved handling of EXDATE so that also the first event of a recurrent set can be excluded.
Basic parse Recurrence-ID (only one Recurrence-ID event to replace one occurrence of the recurrent set) to support changes in individual recurrent events in Google Calendar. Remove _ chars from UID.
Changed textdomain from simple_ical to simple-google-icalendar-widget to make translations work by following the WP standard.
Add help text's in block settings panel.